### PR TITLE
fix dingtalk message sender id & update dingtalk streaming card without content

### DIFF
--- a/pkg/pipeline/bansess/bansess.py
+++ b/pkg/pipeline/bansess/bansess.py
@@ -27,7 +27,7 @@ class BanSessionCheckStage(stage.PipelineStage):
             found = True
         else:
             for sess in sess_list:
-                if sess == f'{query.launcher_type.value}_{query.launcher_id}':
+                if sess == f'{query.launcher_type.value}_{query.launcher_id}' or sess == query.launcher_id:
                     found = True
                     break
 

--- a/pkg/platform/sources/dingtalk.py
+++ b/pkg/platform/sources/dingtalk.py
@@ -61,7 +61,7 @@ class DingTalkEventConverter(adapter.EventConverter):
         if event.conversation == 'FriendMessage':
             return platform_events.FriendMessage(
                 sender=platform_entities.Friend(
-                    id=event.incoming_message.sender_id,
+                    id=event.incoming_message.sender_staff_id,
                     nickname=event.incoming_message.sender_nick,
                     remark='',
                 ),
@@ -71,7 +71,7 @@ class DingTalkEventConverter(adapter.EventConverter):
             )
         elif event.conversation == 'GroupMessage':
             sender = platform_entities.GroupMember(
-                id=event.incoming_message.sender_id,
+                id=event.incoming_message.sender_staff_id,
                 member_name=event.incoming_message.sender_nick,
                 permission='MEMBER',
                 group=platform_entities.Group(
@@ -166,8 +166,11 @@ class DingTalkAdapter(adapter.MessagePlatformAdapter):
             content, at = await DingTalkMessageConverter.yiri2target(message)
 
             card_instance, card_instance_id = self.card_instance_id_dict[message_id]
+            if not content and bot_message.content:
+                content = bot_message.content   # 兼容直接传入content的情况
             # print(card_instance_id)
-            await self.bot.send_card_message(card_instance, card_instance_id, content, is_final)
+            if content:
+                await self.bot.send_card_message(card_instance, card_instance_id, content, is_final)
             if is_final and bot_message.tool_calls is None:
                 # self.seq = 1  # 消息回复结束之后重置seq
                 self.card_instance_id_dict.pop(message_id)  # 消息回复结束之后删除卡片实例id


### PR DESCRIPTION
## 概述 / Overview

> 请在此部分填写你实现/解决/优化的内容:  1.修复接收钉钉消息时，用户id为发送id，而不是用户id，导致不容易进行加白和拉黑;2.修复流式输出时，更新卡片内容为空的情况导致卡片没有显示的bug;3.修复黑名名单中需要分别设置群用户和私聊用户id
> Summary of what you implemented/solved/optimized:

## 检查清单 / Checklist

### PR 作者完成 / For PR author

*请在方括号间写`x`以打勾 / Please tick the box with `x`*

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [ ] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] 文档编写了吗？ / Have you written the documentation?