### PR TITLE
Fix: Correct data type mismatch in AtBotRule

### DIFF
--- a/pkg/pipeline/resprule/rules/atbot.py
+++ b/pkg/pipeline/resprule/rules/atbot.py
@@ -21,7 +21,7 @@ class AtBotRule(rule_model.GroupRespondRule):
         def remove_at(message_chain: platform_message.MessageChain):
             nonlocal found
             for component in message_chain.root:
-                if isinstance(component, platform_message.At) and component.target == query.adapter.bot_account_id:
+                if isinstance(component, platform_message.At) and str(component.target) == str(query.adapter.bot_account_id):
                     message_chain.remove(component)
                     found = True
                     break


### PR DESCRIPTION
Fix can't '@' in QQ group.

## 概述 / Overview

> 请在此部分填写你实现/解决/优化的内容:  
> Summary of what you implemented/solved/optimized: Fix: Correct data type mismatch in AtBotRule, let "@" can work in QQ group.

## 检查清单 / Checklist

### PR 作者完成 / For PR author

*请在方括号间写`x`以打勾 / Please tick the box with `x`*

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [x] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] 文档编写了吗？ / Have you written the documentation?