### PR TITLE
fix(utils): handle missing funcschema parameter docs

### DIFF
--- a/src/langbot/pkg/utils/funcschema.py
+++ b/src/langbot/pkg/utils/funcschema.py
@@ -83,7 +83,7 @@ def get_func_schema(function: typing.Callable) -> dict:
 
         parameters['properties'][param.name] = {
             'type': param_type,
-            'description': args_doc[param.name],
+            'description': args_doc.get(param.name, ''),
         }
 
         # add schema for array

--- a/tests/unit_tests/utils/test_funcschema.py
+++ b/tests/unit_tests/utils/test_funcschema.py
@@ -1,0 +1,15 @@
+from langbot.pkg.utils.funcschema import get_func_schema
+
+
+def test_get_func_schema_uses_empty_description_for_undocumented_parameter():
+    def sample_function(documented: str, undocumented: int):
+        """Sample function.
+
+        Args:
+            documented(str): documented parameter description
+        """
+
+    schema = get_func_schema(sample_function)
+
+    assert schema['parameters']['properties']['documented']['description'] == 'documented parameter description'
+    assert schema['parameters']['properties']['undocumented']['description'] == ''


### PR DESCRIPTION
## Summary
- Avoid `KeyError` in `get_func_schema` when a function parameter is missing from the docstring args section.
- Preserve existing documented parameter descriptions and default missing descriptions to an empty string.
- Add a regression test for documented and undocumented parameters.

Fixes #2172

## Tests
- `uv run ruff check src/langbot/pkg/utils/funcschema.py tests/unit_tests/utils/test_funcschema.py`
- `uv run pytest tests/unit_tests/utils/test_funcschema.py`