### PR TITLE
fix(plugin): use specific runtime not connected error

### DIFF
--- a/src/langbot/pkg/plugin/connector.py
+++ b/src/langbot/pkg/plugin/connector.py
@@ -35,6 +35,10 @@ from ..core import taskmgr
 from ..entity.persistence import plugin as persistence_plugin
 
 
+class PluginRuntimeNotConnectedError(RuntimeError):
+    """Raised when plugin runtime operations are requested before connection."""
+
+
 class PluginRuntimeConnector:
     """Plugin runtime connector"""
 
@@ -192,7 +196,7 @@ class PluginRuntimeConnector:
 
     async def ping_plugin_runtime(self):
         if not hasattr(self, 'handler'):
-            raise Exception('Plugin runtime is not connected')
+            raise PluginRuntimeNotConnectedError('Plugin runtime is not connected')
 
         return await self.handler.ping()
 

--- a/tests/unit_tests/plugin/test_connector_ping.py
+++ b/tests/unit_tests/plugin/test_connector_ping.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from langbot.pkg.plugin.connector import PluginRuntimeConnector, PluginRuntimeNotConnectedError
+
+
+def make_connector() -> PluginRuntimeConnector:
+    app = SimpleNamespace(instance_config=SimpleNamespace(data={'plugin': {'enable': True}}))
+    return PluginRuntimeConnector(app, AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_ping_plugin_runtime_raises_specific_error_when_not_connected():
+    connector = make_connector()
+
+    with pytest.raises(PluginRuntimeNotConnectedError, match='Plugin runtime is not connected'):
+        await connector.ping_plugin_runtime()
+
+
+@pytest.mark.asyncio
+async def test_ping_plugin_runtime_delegates_to_connected_handler():
+    connector = make_connector()
+    connector.handler = SimpleNamespace(ping=AsyncMock(return_value='pong'))
+
+    result = await connector.ping_plugin_runtime()
+
+    assert result == 'pong'
+    connector.handler.ping.assert_awaited_once()


### PR DESCRIPTION
## Summary

Introduces a specific exception for plugin runtime operations attempted before a runtime connection exists.

## Bug

`PluginRuntimeConnector.ping_plugin_runtime()` raised a generic `Exception("Plugin runtime is not connected")`, making callers and tests rely on broad exception matching.

Tracked in #2181.

## Changes

- Add `PluginRuntimeNotConnectedError(RuntimeError)`.
- Raise the specific exception when `handler` has not been connected.
- Add regression tests for disconnected and connected ping behavior.

## Tests

```bash
uv run ruff check src/langbot/pkg/plugin/connector.py tests/unit_tests/plugin/test_connector_ping.py --output-format=concise
uv run pytest tests/unit_tests/plugin/test_connector_ping.py -q --tb=short
```
