### PR TITLE
[codex] Delegate web page bot stream helpers

### DIFF
--- a/src/langbot/pkg/platform/sources/web_page_bot_adapter.py
+++ b/src/langbot/pkg/platform/sources/web_page_bot_adapter.py
@@ -90,9 +90,7 @@ class WebPageBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter
             return await self._ws_adapter.is_stream_output_supported()
         return False
 
-    async def create_message_card(
-        self, message_id: str | int, event: platform_events.MessageEvent
-    ) -> bool:
+    async def create_message_card(self, message_id: str | int, event: platform_events.MessageEvent) -> bool:
         """Delegate create_message_card to ws_adapter."""
         if self._ws_adapter is not None:
             return await self._ws_adapter.create_message_card(message_id, event)

--- a/src/langbot/pkg/platform/sources/web_page_bot_adapter.py
+++ b/src/langbot/pkg/platform/sources/web_page_bot_adapter.py
@@ -84,6 +84,20 @@ class WebPageBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter
     ):
         self.listeners.pop(event_type, None)
 
+    async def is_stream_output_supported(self) -> bool:
+        """Delegate stream output check to ws_adapter."""
+        if self._ws_adapter is not None:
+            return await self._ws_adapter.is_stream_output_supported()
+        return False
+
+    async def create_message_card(
+        self, message_id: str | int, event: platform_events.MessageEvent
+    ) -> bool:
+        """Delegate create_message_card to ws_adapter."""
+        if self._ws_adapter is not None:
+            return await self._ws_adapter.create_message_card(message_id, event)
+        return False
+
     async def is_muted(self, group_id: int) -> bool:
         return False
 


### PR DESCRIPTION
## Summary

Split the web page bot adapter helper delegation out of #2210 into a focused PR.

This adds delegation from `WebPageBotAdapter` to the underlying WebSocket adapter for:

- `is_stream_output_supported()`
- `create_message_card(...)`

## Validation

- `python3 -m py_compile src/langbot/pkg/platform/sources/web_page_bot_adapter.py`

Related: #2210
