### PR TITLE
[codex] cover frontend CRUD smoke flows

### DIFF
--- a/web/tests/e2e/crud-smoke.spec.ts
+++ b/web/tests/e2e/crud-smoke.spec.ts
@@ -1,0 +1,168 @@
+import { expect, Page, test } from '@playwright/test';
+
+import { installLangBotApiMocks } from './fixtures/langbot-api';
+
+async function save(page: Page) {
+  const button = page.getByRole('button', { name: /^Save$/ });
+  await expect(button).toBeEnabled();
+  await button.click();
+}
+
+async function submit(page: Page) {
+  await page.getByRole('button', { name: /^Submit$/ }).click();
+}
+
+async function confirmDelete(page: Page) {
+  await page
+    .getByRole('dialog')
+    .getByRole('button', { name: /^Confirm Delete$/ })
+    .click();
+}
+
+test.describe('frontend CRUD smoke flows', () => {
+  test('creates, edits, and deletes a pipeline', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    await page.goto('/home/pipelines?id=new');
+
+    await expect(page.locator('input[name="basic.name"]')).toBeVisible();
+    await page.locator('input[name="basic.name"]').fill('Escalation Pipeline');
+    await page
+      .locator('input[name="basic.description"]')
+      .fill('Routes urgent customer issues.');
+    await submit(page);
+
+    await expect(page).toHaveURL(/\/home\/pipelines\?id=pipeline-1$/);
+    await page.reload();
+    await expect(page.locator('input[name="basic.name"]')).toHaveValue(
+      'Escalation Pipeline',
+    );
+
+    await page
+      .locator('input[name="basic.description"]')
+      .fill('Routes urgent customer issues to operators.');
+    await save(page);
+    await expect(page.locator('input[name="basic.description"]')).toHaveValue(
+      'Routes urgent customer issues to operators.',
+    );
+
+    await page.getByRole('button', { name: /^Delete$/ }).click();
+    await confirmDelete(page);
+
+    await expect(page).toHaveURL(/\/home\/pipelines$/);
+    await expect(
+      page.getByText('Select a pipeline from the sidebar'),
+    ).toBeVisible();
+  });
+
+  test('creates, edits, and deletes a knowledge base', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    await page.goto('/home/knowledge?id=new');
+
+    await expect(page.locator('input[name="name"]')).toBeVisible();
+    await page.locator('input[name="name"]').fill('Support Knowledge');
+    await page
+      .locator('input[name="description"]')
+      .fill('Source material for support answers.');
+    await submit(page);
+
+    await expect(page).toHaveURL(/\/home\/knowledge\?id=knowledge-1$/);
+    await page.reload();
+    await expect(page.locator('input[name="name"]')).toHaveValue(
+      'Support Knowledge',
+    );
+    await page.waitForTimeout(600);
+
+    await page
+      .locator('input[name="description"]')
+      .fill('Updated source material for support answers.');
+    await save(page);
+    await expect(page.locator('input[name="description"]')).toHaveValue(
+      'Updated source material for support answers.',
+    );
+
+    await page.getByRole('button', { name: /^Delete$/ }).click();
+    await confirmDelete(page);
+
+    await expect(page).toHaveURL(/\/home\/knowledge$/);
+    await expect(
+      page.getByText('Select a knowledge base from the sidebar'),
+    ).toBeVisible();
+  });
+
+  test('creates, edits, and deletes an MCP server', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    await page.goto('/home/mcp?id=new');
+
+    await expect(page.locator('input[name="name"]')).toBeVisible();
+    await page.locator('input[name="name"]').fill('playwright-mcp');
+    await page
+      .locator('input[name="url"]')
+      .fill('https://mcp.example.test/sse');
+    await submit(page);
+
+    await expect(page).toHaveURL(/\/home\/mcp\?id=playwright-mcp$/);
+    await page.reload();
+    await expect(page.locator('input[name="name"]')).toHaveValue(
+      'playwright-mcp',
+    );
+
+    await page
+      .locator('input[name="url"]')
+      .fill('https://mcp.example.test/updated-sse');
+    await save(page);
+    await expect(page.locator('input[name="url"]')).toHaveValue(
+      'https://mcp.example.test/updated-sse',
+    );
+
+    await page.getByRole('button', { name: /^Delete$/ }).click();
+    await confirmDelete(page);
+
+    await expect(page).toHaveURL(/\/home\/mcp$/);
+    await expect(
+      page.getByText('Select an MCP server from the sidebar'),
+    ).toBeVisible();
+  });
+
+  test('updates and deletes a manually-created skill', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    await page.goto('/home/skills?action=create');
+
+    await page.locator('#display_name').fill('Release Notes');
+    await page.locator('#name').fill('release_notes');
+    await page.locator('#description').fill('Drafts release notes.');
+    await page
+      .locator('#instructions')
+      .fill('Summarize merged changes for the next release.');
+    await save(page);
+
+    await expect(page).toHaveURL(/\/home\/skills\?id=release_notes$/);
+    await page.reload();
+    await expect(page.locator('#description')).toHaveValue(
+      'Drafts release notes.',
+    );
+
+    await page
+      .locator('#description')
+      .fill('Drafts concise release notes for maintainers.');
+    await expect(page.locator('#description')).toHaveValue(
+      'Drafts concise release notes for maintainers.',
+    );
+    await save(page);
+    await page.reload();
+    await expect(page.locator('#description')).toHaveValue(
+      'Drafts concise release notes for maintainers.',
+    );
+    await expect(page.locator('#instructions')).toHaveValue(
+      'Summarize merged changes for the next release.',
+    );
+
+    await page.getByRole('button', { name: /^Delete$/ }).click();
+    await confirmDelete(page);
+
+    await expect(page).toHaveURL(/\/home\/add-extension$/);
+  });
+});

--- a/web/tests/e2e/crud-smoke.spec.ts
+++ b/web/tests/e2e/crud-smoke.spec.ts
@@ -20,6 +20,39 @@ async function confirmDelete(page: Page) {
 }
 
 test.describe('frontend CRUD smoke flows', () => {
+  test('creates, edits, and deletes a bot', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    await page.goto('/home/bots?id=new');
+
+    await expect(page.locator('input[name="name"]')).toBeVisible();
+    await page.locator('input[name="name"]').fill('Support Bot');
+    await page
+      .locator('input[name="description"]')
+      .fill('Answers customer support questions.');
+    await page.getByRole('combobox').click();
+    await page.getByRole('option', { name: 'Playwright Adapter' }).click();
+    await submit(page);
+
+    await expect(page).toHaveURL(/\/home\/bots\?id=bot-1$/);
+    await page.reload();
+    await expect(page.locator('input[name="name"]')).toHaveValue('Support Bot');
+
+    await page
+      .locator('input[name="description"]')
+      .fill('Answers customer support questions with context.');
+    await save(page);
+    await expect(page.locator('input[name="description"]')).toHaveValue(
+      'Answers customer support questions with context.',
+    );
+
+    await page.getByRole('button', { name: /^Delete$/ }).click();
+    await confirmDelete(page);
+
+    await expect(page).toHaveURL(/\/home\/bots$/);
+    await expect(page.getByText('Select a bot from the sidebar')).toBeVisible();
+  });
+
   test('creates, edits, and deletes a pipeline', async ({ page }) => {
     await installLangBotApiMocks(page, { authenticated: true });
 

--- a/web/tests/e2e/crud-smoke.spec.ts
+++ b/web/tests/e2e/crud-smoke.spec.ts
@@ -199,3 +199,257 @@ test.describe('frontend CRUD smoke flows', () => {
     await expect(page).toHaveURL(/\/home\/add-extension$/);
   });
 });
+
+test.describe('bot advanced flows', () => {
+  test('toggles bot enable/disable state', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    // Create a bot first
+    await page.goto('/home/bots?id=new');
+    await page.locator('input[name="name"]').fill('Toggle Test Bot');
+    await page.getByRole('combobox').click();
+    await page.getByRole('option', { name: 'Playwright Adapter' }).click();
+    await submit(page);
+
+    await expect(page).toHaveURL(/\/home\/bots\?id=bot-1$/);
+
+    // Wait for the enable switch to load (it's fetched via getBot)
+    await expect(page.locator('#bot-enable-switch')).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Verify initial state is enabled
+    await expect(page.locator('#bot-enable-switch')).toBeChecked();
+
+    // Toggle to disabled
+    await page.locator('#bot-enable-switch').click();
+    await expect(page.locator('#bot-enable-switch')).not.toBeChecked();
+
+    // Reload and verify state persisted
+    await page.reload();
+    await expect(page.locator('#bot-enable-switch')).not.toBeChecked();
+  });
+
+  test('switches between bot detail tabs', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    // Create a bot
+    await page.goto('/home/bots?id=new');
+    await page.locator('input[name="name"]').fill('Tab Test Bot');
+    await page.getByRole('combobox').click();
+    await page.getByRole('option', { name: 'Playwright Adapter' }).click();
+    await submit(page);
+
+    // Verify we're on the Configuration tab
+    await expect(
+      page.getByRole('tab', { name: /Configuration/ }),
+    ).toHaveAttribute('data-state', 'active');
+    await expect(page.locator('input[name="name"]')).toBeVisible();
+
+    // Switch to Logs tab
+    await page.getByRole('tab', { name: /Logs/ }).click();
+    await expect(page.getByRole('tab', { name: /Logs/ })).toHaveAttribute(
+      'data-state',
+      'active',
+    );
+
+    // Switch to Sessions tab
+    await page.getByRole('tab', { name: /Sessions/ }).click();
+    await expect(page.getByRole('tab', { name: /Sessions/ })).toHaveAttribute(
+      'data-state',
+      'active',
+    );
+
+    // Switch back to Configuration
+    await page.getByRole('tab', { name: /Configuration/ }).click();
+    await expect(page.locator('input[name="name"]')).toBeVisible();
+  });
+
+  test('save button is disabled when form is clean', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    // Create a bot
+    await page.goto('/home/bots?id=new');
+    await page.locator('input[name="name"]').fill('Clean Form Bot');
+    await page.getByRole('combobox').click();
+    await page.getByRole('option', { name: 'Playwright Adapter' }).click();
+    await submit(page);
+
+    // After creation, save button should be disabled (form is clean)
+    const saveButton = page.getByRole('button', { name: /^Save$/ });
+    await expect(saveButton).toBeDisabled();
+
+    // Edit the form
+    await page.locator('input[name="description"]').fill('New description');
+    await expect(saveButton).toBeEnabled();
+
+    // Save
+    await saveButton.click();
+    await expect(saveButton).toBeDisabled();
+  });
+
+  test('shows validation error when bot name is empty', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    await page.goto('/home/bots?id=new');
+
+    // Select adapter but leave name empty
+    await page.getByRole('combobox').click();
+    await page.getByRole('option', { name: 'Playwright Adapter' }).click();
+    await submit(page);
+
+    // Should show validation error for name (zod validation)
+    await expect(page.getByText(/cannot be empty/i)).toBeVisible();
+    await expect(page).toHaveURL(/\/home\/bots\?id=new$/);
+  });
+});
+
+test.describe('pipeline advanced flows', () => {
+  test('switches to monitoring tab from pipeline detail', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    // Create a pipeline
+    await page.goto('/home/pipelines?id=new');
+    await page.locator('input[name="basic.name"]').fill('Tab Test Pipeline');
+    await submit(page);
+
+    // Verify we're on the Configuration tab
+    await expect(
+      page.getByRole('tab', { name: /Configuration/ }),
+    ).toHaveAttribute('data-state', 'active');
+
+    // Switch to Monitoring tab (labeled "Dashboard" in the pipeline context)
+    // Skip Debug tab as it requires WebSocket connection
+    await page.getByRole('tab', { name: /Dashboard/ }).click();
+    await expect(page.getByRole('tab', { name: /Dashboard/ })).toHaveAttribute(
+      'data-state',
+      'active',
+    );
+
+    // Switch back to Configuration
+    await page.getByRole('tab', { name: /Configuration/ }).click();
+    await expect(page.locator('input[name="basic.name"]')).toBeVisible();
+  });
+
+  test('save button reflects form dirty state', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    // Create a pipeline
+    await page.goto('/home/pipelines?id=new');
+    await page.locator('input[name="basic.name"]').fill('Dirty Form Pipeline');
+    await submit(page);
+
+    // Wait for the page to fully load and form to reset
+    await page.waitForTimeout(500);
+
+    // Edit the form - use the name field which definitely triggers dirty state
+    await page
+      .locator('input[name="basic.name"]')
+      .fill('Dirty Form Pipeline Updated');
+    const saveButton = page.getByRole('button', { name: /^Save$/ });
+    await expect(saveButton).toBeEnabled();
+
+    // Save
+    await saveButton.click();
+    // Wait for save to complete
+    await page.waitForTimeout(500);
+  });
+
+  test('shows validation error when pipeline name is empty', async ({
+    page,
+  }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    await page.goto('/home/pipelines?id=new');
+
+    // Submit without filling name
+    await submit(page);
+
+    // Should show validation error for name (zod validation)
+    await expect(page.getByText(/cannot be empty/i)).toBeVisible();
+    await expect(page).toHaveURL(/\/home\/pipelines\?id=new$/);
+  });
+});
+
+test.describe('cross-resource flows', () => {
+  test('creates a pipeline then binds it to a bot', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    // Create a pipeline first
+    await page.goto('/home/pipelines?id=new');
+    await page.locator('input[name="basic.name"]').fill('Production Pipeline');
+    await submit(page);
+    await expect(page).toHaveURL(/\/home\/pipelines\?id=pipeline-1$/);
+
+    // Create a bot
+    await page.goto('/home/bots?id=new');
+    await page.locator('input[name="name"]').fill('Bound Bot');
+    await page.getByRole('combobox').click();
+    await page.getByRole('option', { name: 'Playwright Adapter' }).click();
+    await submit(page);
+    await expect(page).toHaveURL(/\/home\/bots\?id=bot-1$/);
+
+    // Wait for form to fully load
+    await expect(page.locator('input[name="name"]')).toHaveValue('Bound Bot');
+
+    // Find the pipeline select by its label "Bind Pipeline"
+    const pipelineCard = page.getByText('Bind Pipeline').locator('..');
+    await expect(pipelineCard).toBeVisible({ timeout: 5000 });
+
+    // Click on the select trigger within the pipeline binding card
+    // The select trigger shows "Select Pipeline" placeholder initially
+    const pipelineSelectTrigger = page.getByText('Select Pipeline').first();
+    await pipelineSelectTrigger.click();
+
+    // Select the pipeline option
+    await page.getByRole('option', { name: 'Production Pipeline' }).click();
+
+    // Save the bot
+    await save(page);
+
+    // Reload and verify binding persisted
+    await page.reload();
+    // The pipeline name should appear in the select trigger (not in sidebar or options)
+    await expect(
+      page
+        .locator('[data-slot="select-trigger"]')
+        .filter({ hasText: 'Production Pipeline' }),
+    ).toBeVisible();
+  });
+});
+
+test.describe('empty states', () => {
+  test('shows empty state when no bots exist', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    await page.goto('/home/bots');
+    await expect(page.getByText('Select a bot from the sidebar')).toBeVisible();
+  });
+
+  test('shows empty state when no pipelines exist', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    await page.goto('/home/pipelines');
+    await expect(
+      page.getByText('Select a pipeline from the sidebar'),
+    ).toBeVisible();
+  });
+
+  test('shows empty state when no knowledge bases exist', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    await page.goto('/home/knowledge');
+    await expect(
+      page.getByText('Select a knowledge base from the sidebar'),
+    ).toBeVisible();
+  });
+
+  test('shows empty state when no MCP servers exist', async ({ page }) => {
+    await installLangBotApiMocks(page, { authenticated: true });
+
+    await page.goto('/home/mcp');
+    await expect(
+      page.getByText('Select an MCP server from the sidebar'),
+    ).toBeVisible();
+  });
+});

--- a/web/tests/e2e/fixtures/langbot-api.ts
+++ b/web/tests/e2e/fixtures/langbot-api.ts
@@ -11,7 +11,54 @@ interface SkillMock {
   updated_at: string;
 }
 
+interface PipelineMock {
+  uuid: string;
+  name: string;
+  description: string;
+  config: JsonRecord;
+  emoji: string;
+  is_default: boolean;
+  updated_at: string;
+}
+
+interface KnowledgeBaseMock {
+  uuid: string;
+  name: string;
+  description: string;
+  emoji: string;
+  knowledge_engine_plugin_id: string;
+  creation_settings: JsonRecord;
+  retrieval_settings: JsonRecord;
+  knowledge_engine: {
+    plugin_id: string;
+    name: {
+      en_US: string;
+      zh_Hans: string;
+    };
+    capabilities: string[];
+  };
+  updated_at: string;
+}
+
+interface MCPServerMock {
+  name: string;
+  mode: 'sse' | 'stdio' | 'http';
+  enable: boolean;
+  extra_args: JsonRecord;
+  runtime_info: {
+    status: 'connected';
+    tool_count: number;
+    tools: unknown[];
+  };
+  readme: string;
+  updated_at: string;
+}
+
 interface LangBotApiMockState {
+  counters: Record<string, number>;
+  knowledgeBases: KnowledgeBaseMock[];
+  mcpServers: MCPServerMock[];
+  pipelines: PipelineMock[];
   skills: SkillMock[];
 }
 
@@ -34,6 +81,19 @@ async function fulfillJson(route: Route, data: unknown) {
 
 function routePath(route: Route) {
   return new URL(route.request().url()).pathname;
+}
+
+function parseJsonBody(route: Route): JsonRecord {
+  return JSON.parse(route.request().postData() || '{}') as JsonRecord;
+}
+
+function now() {
+  return new Date().toISOString();
+}
+
+function nextId(state: LangBotApiMockState, prefix: string) {
+  state.counters[prefix] = (state.counters[prefix] || 0) + 1;
+  return `${prefix}-${state.counters[prefix]}`;
 }
 
 function emptyMonitoringData() {
@@ -90,6 +150,86 @@ function makeSkill(data: JsonRecord): SkillMock {
     instructions: String(data.instructions || ''),
     package_root: String(data.package_root || ''),
     updated_at: new Date().toISOString(),
+  };
+}
+
+function makePipeline(
+  state: LangBotApiMockState,
+  data: JsonRecord,
+  uuid = nextId(state, 'pipeline'),
+): PipelineMock {
+  return {
+    uuid,
+    name: String(data.name || ''),
+    description: String(data.description || ''),
+    config: (data.config as JsonRecord | undefined) || {
+      ai: {},
+      trigger: {},
+      safety: {},
+      output: {},
+    },
+    emoji: String(data.emoji || '⚙️'),
+    is_default: false,
+    updated_at: now(),
+  };
+}
+
+function knowledgeEngine() {
+  return {
+    plugin_id: 'builtin/minimal-knowledge',
+    name: {
+      en_US: 'Minimal Knowledge Engine',
+      zh_Hans: '最小知识库引擎',
+    },
+    description: {
+      en_US: 'Minimal mocked engine for frontend smoke tests.',
+      zh_Hans: '用于前端冒烟测试的最小模拟引擎。',
+    },
+    capabilities: ['text_retrieval'],
+    creation_schema: [],
+    retrieval_schema: [],
+  };
+}
+
+function makeKnowledgeBase(
+  state: LangBotApiMockState,
+  data: JsonRecord,
+  uuid = nextId(state, 'knowledge'),
+): KnowledgeBaseMock {
+  const engine = knowledgeEngine();
+  return {
+    uuid,
+    name: String(data.name || ''),
+    description: String(data.description || ''),
+    emoji: String(data.emoji || '📚'),
+    knowledge_engine_plugin_id: String(
+      data.knowledge_engine_plugin_id || engine.plugin_id,
+    ),
+    creation_settings: (data.creation_settings as JsonRecord | undefined) || {},
+    retrieval_settings:
+      (data.retrieval_settings as JsonRecord | undefined) || {},
+    knowledge_engine: {
+      plugin_id: engine.plugin_id,
+      name: engine.name,
+      capabilities: engine.capabilities,
+    },
+    updated_at: now(),
+  };
+}
+
+function makeMCPServer(data: JsonRecord): MCPServerMock {
+  return {
+    name: String(data.name || ''),
+    mode: (data.mode as MCPServerMock['mode']) || 'sse',
+    enable: data.enable !== false,
+    extra_args: (data.extra_args as JsonRecord | undefined) || {},
+    runtime_info: {
+      status: 'connected',
+      tool_count: 0,
+      tools: [],
+    },
+    readme: '',
+    updated_at: now(),
   };
 }
 
@@ -151,12 +291,117 @@ async function handleBackendApi(route: Route, state: LangBotApiMockState) {
     return fulfillJson(route, { bots: [] });
   }
 
+  if (path === '/api/v1/pipelines/_/metadata') {
+    return fulfillJson(route, { configs: [] });
+  }
+
   if (path === '/api/v1/pipelines') {
-    return fulfillJson(route, { pipelines: [] });
+    if (method === 'POST') {
+      const pipeline = makePipeline(state, parseJsonBody(route));
+      state.pipelines = [
+        ...state.pipelines.filter((item) => item.uuid !== pipeline.uuid),
+        pipeline,
+      ];
+      return fulfillJson(route, { uuid: pipeline.uuid });
+    }
+
+    return fulfillJson(route, { pipelines: state.pipelines });
+  }
+
+  const pipelineMatch = path.match(/^\/api\/v1\/pipelines\/([^/]+)$/);
+  if (pipelineMatch) {
+    const pipelineId = decodeURIComponent(pipelineMatch[1]);
+
+    if (method === 'PUT') {
+      const pipeline = makePipeline(state, parseJsonBody(route), pipelineId);
+      state.pipelines = [
+        ...state.pipelines.filter((item) => item.uuid !== pipelineId),
+        pipeline,
+      ];
+      return fulfillJson(route, {});
+    }
+
+    if (method === 'DELETE') {
+      state.pipelines = state.pipelines.filter(
+        (item) => item.uuid !== pipelineId,
+      );
+      return fulfillJson(route, {});
+    }
+
+    const pipeline = state.pipelines.find((item) => item.uuid === pipelineId);
+    return fulfillJson(route, {
+      pipeline:
+        pipeline || makePipeline(state, { name: pipelineId }, pipelineId),
+    });
+  }
+
+  const pipelineExtensionsMatch = path.match(
+    /^\/api\/v1\/pipelines\/([^/]+)\/extensions$/,
+  );
+  if (pipelineExtensionsMatch) {
+    return fulfillJson(route, {
+      enable_all_plugins: true,
+      enable_all_mcp_servers: true,
+      enable_all_skills: true,
+      bound_plugins: [],
+      available_plugins: [],
+      bound_mcp_servers: [],
+      available_mcp_servers: state.mcpServers,
+      bound_skills: [],
+      available_skills: state.skills,
+    });
   }
 
   if (path === '/api/v1/knowledge/bases') {
-    return fulfillJson(route, { bases: [] });
+    if (method === 'POST') {
+      const base = makeKnowledgeBase(state, parseJsonBody(route));
+      state.knowledgeBases = [
+        ...state.knowledgeBases.filter((item) => item.uuid !== base.uuid),
+        base,
+      ];
+      return fulfillJson(route, { uuid: base.uuid });
+    }
+
+    return fulfillJson(route, { bases: state.knowledgeBases });
+  }
+
+  const knowledgeBaseFilesMatch = path.match(
+    /^\/api\/v1\/knowledge\/bases\/([^/]+)\/files$/,
+  );
+  if (knowledgeBaseFilesMatch) {
+    return fulfillJson(route, { files: [] });
+  }
+
+  const knowledgeBaseMatch = path.match(
+    /^\/api\/v1\/knowledge\/bases\/([^/]+)$/,
+  );
+  if (knowledgeBaseMatch) {
+    const baseId = decodeURIComponent(knowledgeBaseMatch[1]);
+
+    if (method === 'PUT') {
+      const base = makeKnowledgeBase(state, parseJsonBody(route), baseId);
+      state.knowledgeBases = [
+        ...state.knowledgeBases.filter((item) => item.uuid !== baseId),
+        base,
+      ];
+      return fulfillJson(route, { uuid: base.uuid });
+    }
+
+    if (method === 'DELETE') {
+      state.knowledgeBases = state.knowledgeBases.filter(
+        (item) => item.uuid !== baseId,
+      );
+      return fulfillJson(route, {});
+    }
+
+    const base = state.knowledgeBases.find((item) => item.uuid === baseId);
+    return fulfillJson(route, {
+      base: base || makeKnowledgeBase(state, { name: baseId }, baseId),
+    });
+  }
+
+  if (path === '/api/v1/knowledge/engines') {
+    return fulfillJson(route, { engines: [knowledgeEngine()] });
   }
 
   if (path === '/api/v1/knowledge/migration/status') {
@@ -176,7 +421,60 @@ async function handleBackendApi(route: Route, state: LangBotApiMockState) {
   }
 
   if (path === '/api/v1/mcp/servers') {
-    return fulfillJson(route, { servers: [] });
+    if (method === 'POST') {
+      const server = makeMCPServer(parseJsonBody(route));
+      state.mcpServers = [
+        ...state.mcpServers.filter((item) => item.name !== server.name),
+        server,
+      ];
+      return fulfillJson(route, { task_id: nextId(state, 'task') });
+    }
+
+    return fulfillJson(route, { servers: state.mcpServers });
+  }
+
+  const mcpTestMatch = path.match(/^\/api\/v1\/mcp\/servers\/([^/]+)\/test$/);
+  if (mcpTestMatch) {
+    return fulfillJson(route, {
+      runtime_info: {
+        status: 'connected',
+        tool_count: 0,
+        tools: [],
+      },
+    });
+  }
+
+  const mcpServerMatch = path.match(/^\/api\/v1\/mcp\/servers\/([^/]+)$/);
+  if (mcpServerMatch) {
+    const serverName = decodeURIComponent(mcpServerMatch[1]);
+
+    if (method === 'PUT') {
+      const existing = state.mcpServers.find(
+        (item) => item.name === serverName,
+      );
+      const server = makeMCPServer({
+        ...(existing || {}),
+        ...parseJsonBody(route),
+        name: serverName,
+      });
+      state.mcpServers = [
+        ...state.mcpServers.filter((item) => item.name !== serverName),
+        server,
+      ];
+      return fulfillJson(route, { task_id: nextId(state, 'task') });
+    }
+
+    if (method === 'DELETE') {
+      state.mcpServers = state.mcpServers.filter(
+        (item) => item.name !== serverName,
+      );
+      return fulfillJson(route, { task_id: nextId(state, 'task') });
+    }
+
+    const server = state.mcpServers.find((item) => item.name === serverName);
+    return fulfillJson(route, {
+      server: server || makeMCPServer({ name: serverName }),
+    });
   }
 
   if (path === '/api/v1/skills') {
@@ -229,6 +527,23 @@ async function handleBackendApi(route: Route, state: LangBotApiMockState) {
   const skillMatch = path.match(/^\/api\/v1\/skills\/([^/]+)$/);
   if (skillMatch) {
     const skillName = decodeURIComponent(skillMatch[1]);
+    if (method === 'PUT') {
+      const skill = makeSkill({
+        ...parseJsonBody(route),
+        name: skillName,
+      });
+      state.skills = [
+        ...state.skills.filter((item) => item.name !== skillName),
+        skill,
+      ];
+      return fulfillJson(route, { skill });
+    }
+
+    if (method === 'DELETE') {
+      state.skills = state.skills.filter((item) => item.name !== skillName);
+      return fulfillJson(route, {});
+    }
+
     const skill = state.skills.find((item) => item.name === skillName) || {
       name: skillName,
       display_name: '',
@@ -389,6 +704,10 @@ export async function installLangBotApiMocks(
 ) {
   const { authenticated = false, storage = {} } = options;
   const state: LangBotApiMockState = {
+    counters: {},
+    knowledgeBases: [],
+    mcpServers: [],
+    pipelines: [],
     skills: [],
   };
 

--- a/web/tests/e2e/fixtures/langbot-api.ts
+++ b/web/tests/e2e/fixtures/langbot-api.ts
@@ -54,7 +54,21 @@ interface MCPServerMock {
   updated_at: string;
 }
 
+interface BotMock {
+  uuid: string;
+  name: string;
+  description: string;
+  enable: boolean;
+  adapter: string;
+  adapter_config: JsonRecord;
+  use_pipeline_uuid?: string;
+  pipeline_routing_rules: unknown[];
+  adapter_runtime_values: JsonRecord;
+  updated_at: string;
+}
+
 interface LangBotApiMockState {
+  bots: BotMock[];
   counters: Record<string, number>;
   knowledgeBases: KnowledgeBaseMock[];
   mcpServers: MCPServerMock[];
@@ -233,6 +247,51 @@ function makeMCPServer(data: JsonRecord): MCPServerMock {
   };
 }
 
+function makeBot(
+  state: LangBotApiMockState,
+  data: JsonRecord,
+  uuid = nextId(state, 'bot'),
+): BotMock {
+  return {
+    uuid,
+    name: String(data.name || ''),
+    description: String(data.description || ''),
+    enable: data.enable !== false,
+    adapter: String(data.adapter || 'playwright-adapter'),
+    adapter_config: (data.adapter_config as JsonRecord | undefined) || {},
+    use_pipeline_uuid: data.use_pipeline_uuid
+      ? String(data.use_pipeline_uuid)
+      : undefined,
+    pipeline_routing_rules:
+      (data.pipeline_routing_rules as unknown[] | undefined) || [],
+    adapter_runtime_values: {
+      webhook_full_url: `https://playwright.test/bots/${uuid}/webhook`,
+      extra_webhook_full_url: '',
+    },
+    updated_at: now(),
+  };
+}
+
+function mockAdapters() {
+  return [
+    {
+      name: 'playwright-adapter',
+      label: {
+        en_US: 'Playwright Adapter',
+        zh_Hans: 'Playwright 适配器',
+      },
+      description: {
+        en_US: 'Minimal adapter for frontend E2E tests.',
+        zh_Hans: '用于前端 E2E 测试的最小适配器。',
+      },
+      spec: {
+        categories: ['testing'],
+        config: [],
+      },
+    },
+  ];
+}
+
 async function handleBackendApi(route: Route, state: LangBotApiMockState) {
   const request = route.request();
   const url = new URL(request.url());
@@ -287,8 +346,47 @@ async function handleBackendApi(route: Route, state: LangBotApiMockState) {
     return fulfillJson(route, { credits: null });
   }
 
+  if (path === '/api/v1/platform/adapters') {
+    return fulfillJson(route, { adapters: mockAdapters() });
+  }
+
   if (path === '/api/v1/platform/bots') {
-    return fulfillJson(route, { bots: [] });
+    if (method === 'POST') {
+      const bot = makeBot(state, parseJsonBody(route));
+      state.bots = [
+        ...state.bots.filter((item) => item.uuid !== bot.uuid),
+        bot,
+      ];
+      return fulfillJson(route, { uuid: bot.uuid });
+    }
+
+    return fulfillJson(route, { bots: state.bots });
+  }
+
+  const botLogsMatch = path.match(/^\/api\/v1\/platform\/bots\/([^/]+)\/logs$/);
+  if (botLogsMatch) {
+    return fulfillJson(route, { logs: [], total: 0 });
+  }
+
+  const botMatch = path.match(/^\/api\/v1\/platform\/bots\/([^/]+)$/);
+  if (botMatch) {
+    const botId = decodeURIComponent(botMatch[1]);
+
+    if (method === 'PUT') {
+      const bot = makeBot(state, parseJsonBody(route), botId);
+      state.bots = [...state.bots.filter((item) => item.uuid !== botId), bot];
+      return fulfillJson(route, {});
+    }
+
+    if (method === 'DELETE') {
+      state.bots = state.bots.filter((item) => item.uuid !== botId);
+      return fulfillJson(route, {});
+    }
+
+    const bot = state.bots.find((item) => item.uuid === botId);
+    return fulfillJson(route, {
+      bot: bot || makeBot(state, { name: botId }, botId),
+    });
   }
 
   if (path === '/api/v1/pipelines/_/metadata') {
@@ -704,6 +802,7 @@ export async function installLangBotApiMocks(
 ) {
   const { authenticated = false, storage = {} } = options;
   const state: LangBotApiMockState = {
+    bots: [],
     counters: {},
     knowledgeBases: [],
     mcpServers: [],


### PR DESCRIPTION
## Summary

- Add frontend Playwright CRUD smoke coverage for Bot, Pipeline, Knowledge Base, MCP Server, and Skill flows.
- Extend the LangBot frontend API mock fixture with stateful create/read/update/delete handling for bots, pipelines, knowledge bases, MCP servers, and skills.
- Keep the tests backend-free by mocking LangBot backend and Space API calls in the browser.

## Covered flows

- Bot: create with a mocked adapter, reopen details, edit metadata, delete.
- Pipeline: create, reopen details, edit metadata, delete.
- Knowledge Base: create with a mocked Knowledge Engine, reopen details, edit metadata, delete.
- MCP Server: create an SSE server, reopen details, edit URL, delete.
- Skill: create manually, reopen details, edit metadata, delete.

## Validation

- `cd web && pnpm exec playwright test tests/e2e/crud-smoke.spec.ts`
- `cd web && pnpm test:e2e`
- `cd web && pnpm lint`
- `cd web && pnpm build`