### PR TITLE
fix(modelmgr): default Moonshot/Kimi base URL to api.moonshot.cn

### DIFF
--- a/src/langbot/pkg/provider/modelmgr/requesters/moonshotchatcmpl.yaml
+++ b/src/langbot/pkg/provider/modelmgr/requesters/moonshotchatcmpl.yaml
@@ -15,7 +15,7 @@ spec:
       zh_Hans: 基础 URL
     type: string
     required: true
-    default: https://api.moonshot.ai/v1
+    default: https://api.moonshot.cn/v1
   - name: timeout
     label:
       en_US: Timeout


### PR DESCRIPTION
## Summary

Fixes #2232 — adding a Kimi/Moonshot provider with a **CN-region** API key fails model scanning out of the box, because the provider preset defaults its base URL to `https://api.moonshot.ai/v1` (the global endpoint). CN-issued keys are only valid against `https://api.moonshot.cn/v1`, so `GET /v1/models` returns `401 Invalid Authentication` and the provider looks broken until the user manually edits the base URL.

## Root cause

After the LiteLLM unification, the WebUI pre-fills the base URL field from the provider YAML preset (`moonshotchatcmpl.yaml`). That YAML still defaulted to `.ai`, even though every other place that defines a Moonshot default already used `.cn`:

- `src/langbot/templates/legacy/provider.json` → `https://api.moonshot.cn/v1`
- the old per-provider Python requester (`MoonshotChatCompletions`, since removed) → `.cn`
- the DB migration `m004_moonshot_cfg_completion` → `.cn`

So the YAML was the lone straggler pointing at `.ai`.

## Fix

Align the YAML preset default to `https://api.moonshot.cn/v1` to match the rest of the codebase, so CN keys work without manual editing. Users on the global endpoint can still change the field to `.ai`.

One-line change:

```diff
-    default: https://api.moonshot.ai/v1
+    default: https://api.moonshot.cn/v1
```

## Test plan

- [x] YAML parses; `base_url` default resolves to `https://api.moonshot.cn/v1`.
- [x] No remaining `moonshot.ai` references in LangBot source (only inside the vendored `litellm` package, which is unaffected — the preset uses `litellm_provider: openai` and passes the configured base URL through verbatim).