### PR TITLE
feat(modelmgr): split Moonshot/Kimi into Global and China presets

### DIFF
--- a/src/langbot/pkg/provider/modelmgr/requesters/moonshotcnchatcmpl.yaml
+++ b/src/langbot/pkg/provider/modelmgr/requesters/moonshotcnchatcmpl.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: LLMAPIRequester
 metadata:
-  name: moonshot-chat-completions
+  name: moonshot-cn-chat-completions
   label:
-    en_US: Moonshot / Kimi (Global · api.moonshot.ai)
-    zh_Hans: 月之暗面 / Kimi（国际站 · api.moonshot.ai）
+    en_US: Moonshot / Kimi (China · api.moonshot.cn)
+    zh_Hans: 月之暗面 / Kimi（国内站 · api.moonshot.cn）
   icon: moonshot.png
 spec:
   litellm_provider: openai
@@ -15,7 +15,7 @@ spec:
       zh_Hans: 基础 URL
     type: string
     required: true
-    default: https://api.moonshot.ai/v1
+    default: https://api.moonshot.cn/v1
   - name: timeout
     label:
       en_US: Timeout
@@ -23,7 +23,7 @@ spec:
     type: integer
     required: true
     default: 120
-  alias: "moonshot Moonshot 月之暗面 月暗 kimi Kimi 月之 暗面 moonshot-v1 k2"
+  alias: "moonshot Moonshot 月之暗面 月暗 kimi Kimi 月之 暗面 moonshot-v1 k2 cn 国内 国内站"
   support_type:
   - llm
   provider_category: manufacturer


### PR DESCRIPTION
## Summary

Fixes #2232 — adding a Kimi/Moonshot provider with a **CN-region** API key fails model scanning out of the box. The single preset defaulted its base URL to the global endpoint `https://api.moonshot.ai/v1`, but CN-issued keys are only valid against `https://api.moonshot.cn/v1`, so `GET /v1/models` returns `401 Invalid Authentication` and the provider looks broken until the user manually edits the base URL.

## Why not just flip the default to `.cn`?

That only moves the 401 from CN keys to international keys. The `base_url` field is plain free-text, and both regions are common in practice, so there is no single default that works for everyone. (This is why the issue is labelled `pd: Need design`.)

## Approach

Offer two clearly-labelled presets, mirroring how the Lark adapter already exposes `feishu.cn` vs `larksuite.com`:

| Component name | Label | Default base URL |
|---|---|---|
| `moonshot-chat-completions` (unchanged) | Moonshot / Kimi (Global · api.moonshot.ai) | `https://api.moonshot.ai/v1` |
| `moonshot-cn-chat-completions` (new) | Moonshot / Kimi (China · api.moonshot.cn) | `https://api.moonshot.cn/v1` |

Design notes:
- **The existing component `name` is kept unchanged**, so provider rows already in the DB keep resolving — only its display label is clarified. No migration needed.
- **`base_url` stays a free-text field** on both presets, so users behind a proxy / one-api gateway can still enter a custom endpoint (a hard `select` dropdown would have regressed them).
- Both presets carry the same `kimi`/`月之暗面` search aliases, so either one shows up when searching the provider list.
- Both use `litellm_provider: openai`, so the configured base URL is passed through verbatim.

## Test plan

- [x] Both YAMLs parse; `base_url` defaults resolve to `.ai` and `.cn` respectively; component names are unique.
- [x] `ComponentDiscoveryEngine.load_component_manifest` loads both manifests as `kind: LLMAPIRequester` without error.
- [x] `ruff check src/langbot/pkg/provider/modelmgr/` — clean.
- [x] `pytest tests/unit_tests/provider/test_model_service.py test_model_manager.py` — 43 passed.