### PR TITLE
fix(docker): mount box root in app container

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -57,6 +57,7 @@ services:
     container_name: langbot
     volumes:
       - ./data:/app/data
+      - ${LANGBOT_BOX_ROOT:-${PWD}/data/box}:${LANGBOT_BOX_ROOT:-${PWD}/data/box}
     restart: on-failure
     environment:
       - TZ=Asia/Shanghai


### PR DESCRIPTION
## Summary
- Mount the Box root path into the main LangBot container as well as the Box runtime container.
- Keep the host and container path identical so Box initialization writes to the path that sandbox containers can later access.

## Verification
- Validated the Docker Compose config with docker compose -f docker/docker-compose.yaml config --services.