### PR TITLE
fix(api): guard /set-password with allow_modify_login_info

### DIFF
--- a/src/langbot/pkg/api/http/controller/groups/user.py
+++ b/src/langbot/pkg/api/http/controller/groups/user.py
@@ -195,6 +195,13 @@ class UserRouterGroup(group.RouterGroup):
         @self.route('/set-password', methods=['POST'], auth_type=group.AuthType.USER_TOKEN)
         async def _(user_email: str) -> str:
             """Set password for Space account (first time) or change password"""
+            # Check if modifying login info is allowed
+            allow_modify_login_info = self.ap.instance_config.data.get('system', {}).get(
+                'allow_modify_login_info', True
+            )
+            if not allow_modify_login_info:
+                return self.http_status(403, -1, 'Modifying login info is disabled')
+
             json_data = await quart.request.json
             new_password = json_data.get('new_password')
             current_password = json_data.get('current_password')


### PR DESCRIPTION
## Problem

`system.allow_modify_login_info: false` is meant to lock down credential changes on shared/public deployments (e.g. the public demo at demo.langbot.dev). `/api/v1/user/change-password` and `/api/v1/user/bind-space` already honor it and return 403 when disabled.

But `/api/v1/user/set-password` had **no such guard** — an authenticated user could still set/change the local password even when login-info modification is disabled. On the public demo this is an account-takeover surface (the shared demo account could be re-secured by a visitor).

## Fix

Apply the same `allow_modify_login_info` check used by the sibling endpoints, returning 403 when modification is disabled.

## Verification

On a deployment with `allow_modify_login_info: false`, `/set-password` now returns 403 `Modifying login info is disabled`, matching `/change-password` and `/bind-space`.