### PR TITLE
test: use package import paths

### DIFF
--- a/tests/unit_tests/plugin/test_plugin_id_parsing.py
+++ b/tests/unit_tests/plugin/test_plugin_id_parsing.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.langbot.pkg.plugin.connector import PluginRuntimeConnector
+from langbot.pkg.plugin.connector import PluginRuntimeConnector
 
 
 def test_parse_plugin_id_accepts_author_name():

--- a/tests/unit_tests/test_paths.py
+++ b/tests/unit_tests/test_paths.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from src.langbot.pkg.utils import paths
+from langbot.pkg.utils import paths
 
 
 def test_get_data_root_uses_source_root_in_repo_checkout():


### PR DESCRIPTION
## Summary
- Replace remaining test imports that used src.langbot with the installed package path langbot.
- Avoid importing the same source files under duplicate module names in tests.

## Tests
- uv run --frozen pytest tests/unit_tests/test_paths.py tests/unit_tests/plugin/test_plugin_id_parsing.py -q
- uv run --frozen ruff check tests/unit_tests/test_paths.py tests/unit_tests/plugin/test_plugin_id_parsing.py --output-format=concise
- git diff --check
- git diff --cached --check