### PR TITLE
fix(mcp): set _preserve_managed_process before finally in cold-start path

### DIFF
--- a/src/langbot/pkg/provider/tools/loaders/mcp.py
+++ b/src/langbot/pkg/provider/tools/loaders/mcp.py
@@ -439,6 +439,12 @@ class RuntimeMCPSession:
             else:
                 await self._shutdown_event.wait()
 
+        except _ColdStartRetry:
+            # Cold-start in progress: set the preserve flag BEFORE the finally
+            # block runs so it does not stop the live managed process. The outer
+            # _lifecycle_loop_with_retry will reuse it on the next attempt.
+            self._preserve_managed_process = True
+            raise
         except Exception as e:
             self.status = MCPSessionStatus.ERROR
             self.error_message = str(e)


### PR DESCRIPTION
## Problem

`_ColdStartRetry` was being handled in `_lifecycle_loop_with_retry` which set
`_preserve_managed_process = True` — but by then the `finally` block inside
`_lifecycle_loop` had already executed and called `_cleanup_box_stdio_session()`,
which stopped the live managed process (`return_code=143` SIGTERM). The cold-start
retry then restarted a fresh process, eliminating the warm-up advantage and causing
firecrawl-mcp to churn in a loop of ~10s starts instead of waiting out the cold start.

## Fix

Add an explicit `except _ColdStartRetry` inside `_lifecycle_loop` that sets
`_preserve_managed_process = True` *before* re-raising. The `finally` block then
sees the flag and skips `stop_managed_process`, leaving the live process untouched
for the next handshake attempt.

## Verified

Demo logs confirmed: `_ColdStartRetry: firecrawl__firecrawl: handshake not ready during cold start` fired correctly, but the process still exited 143 each time. After this fix the process should survive across retry cycles until the handshake succeeds.

Part of the npx/node cold-start stabilization series (#2306, #2307).
