### PR TITLE
fix(mcp): bump default memory to 1024MB for node (npx) stdio MCP servers

### DIFF
--- a/src/langbot/pkg/provider/tools/loaders/mcp_stdio.py
+++ b/src/langbot/pkg/provider/tools/loaders/mcp_stdio.py
@@ -142,7 +142,15 @@ class BoxStdioSessionRuntime:
             read_only_rootfs=self.config.read_only_rootfs if self.config.read_only_rootfs is not None else False,
             image=self.config.image,
             cpus=self.config.cpus,
-            memory_mb=self.config.memory_mb,
+            # Node.js runtimes (npx/bunx) reserve large virtual address space and
+            # load WebAssembly modules (llhttp) on startup; the default 512 MB
+            # cgroup_mem_max is too small and causes OOM kills (return_code=137).
+            # Auto-bump to 1024 MB when the runner is npx/bunx/pnpm dlx.
+            memory_mb=(
+                (self.config.memory_mb or 1024)
+                if self.server_config.get('command', '') in ('npx', 'bunx', 'pnpm')
+                else self.config.memory_mb
+            ),
             pids_limit=self.config.pids_limit,
             persistent=True,
         )


### PR DESCRIPTION
## Problem
Node.js MCP servers (npx/bunx) were OOM-killed (return_code=137) by the default 512MB nsjail cgroup limit. Node V8 reserves large virtual address space + instantiates WASM modules on startup, exceeding 512MB. Every node-based MCP crash-looped: memory, sequential-thinking, filesystem, weather, docker, excel.

## Root cause
`MCPServerBoxConfig.memory_mb` defaults to None → SDK uses 512MB `cgroup_mem_max` → Node process OOM.

## Fix
When the stdio command is npx/bunx/pnpm, default `memory_mb` to 1024 (unless operator sets it explicitly). Python/uvx servers keep 512MB.

## Verified
Discovered on the box-stability test environment: all 6 node MCPs were being SIGKILLed every few minutes. `pytest -k "mcp or box"`: 211 passed.