### PR TITLE
fix(mcp): harden remote SSE fallback

### DIFF
--- a/src/langbot/pkg/provider/tools/loaders/mcp.py
+++ b/src/langbot/pkg/provider/tools/loaders/mcp.py
@@ -366,9 +366,15 @@ class RuntimeMCPSession:
             await self._init_streamable_http_server()
             return
         except Exception as e:
+            if not self._should_fallback_to_sse(e):
+                self.ap.logger.info(
+                    f'MCP server {self.server_name}: Streamable HTTP transport failed '
+                    f'({self._describe_exception(e)}); not falling back to SSE'
+                )
+                raise
             self.ap.logger.info(
-                f'MCP server {self.server_name}: Streamable HTTP transport failed '
-                f'({self._describe_exception(e)}), falling back to SSE'
+                f'MCP server {self.server_name}: Streamable HTTP initialize failed with a compatible HTTP status '
+                f'({self._describe_exception(e)}), falling back to legacy SSE'
             )
 
         # The Streamable HTTP attempt may have partially entered the transport /
@@ -574,6 +580,33 @@ class RuntimeMCPSession:
         seen: set[str] = set()
         unique = [m for m in leaves if not (m in seen or seen.add(m))]
         return '; '.join(unique) if unique else f'{type(exc).__name__}: {exc}'
+
+    @staticmethod
+    def _iter_exception_leaves(exc: BaseException) -> typing.Iterator[BaseException]:
+        sub = getattr(exc, 'exceptions', None)
+        if sub:  # ExceptionGroup / BaseExceptionGroup
+            for child in sub:
+                yield from RuntimeMCPSession._iter_exception_leaves(child)
+        else:
+            yield exc
+
+    @staticmethod
+    def _should_fallback_to_sse(exc: BaseException) -> bool:
+        """Whether a Streamable HTTP failure matches MCP legacy-SSE fallback.
+
+        The MCP backwards-compatibility path falls back when the initialize POST
+        fails with a 4xx. Treat authentication failures as terminal: retrying as
+        SSE would hide a bad token/header behind a second, noisier failure.
+        """
+        fallback_statuses = {400, 404, 405, 406, 415}
+        for leaf in RuntimeMCPSession._iter_exception_leaves(exc):
+            if isinstance(leaf, httpx.HTTPStatusError):
+                status_code = leaf.response.status_code
+                if status_code in fallback_statuses:
+                    return True
+                if 400 <= status_code < 500 and status_code not in {401, 403}:
+                    return True
+        return False
 
     _MONITOR_POLL_INTERVAL = 5
     _MONITOR_MAX_CONSECUTIVE_ERRORS = 3

--- a/tests/unit_tests/provider/test_mcp_resources.py
+++ b/tests/unit_tests/provider/test_mcp_resources.py
@@ -4,6 +4,7 @@ import base64
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
+import httpx
 import pytest
 from mcp import types as mcp_types
 
@@ -52,6 +53,50 @@ def _connected_session(
 
 def _query() -> SimpleNamespace:
     return SimpleNamespace(variables={})
+
+
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request('POST', 'https://example.com/mcp')
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(f'HTTP {status_code}', request=request, response=response)
+
+
+@pytest.mark.asyncio
+async def test_remote_transport_falls_back_to_sse_for_compatible_http_status_in_exception_group():
+    session = RuntimeMCPSession(
+        'remote',
+        {'uuid': 'srv-1', 'mode': 'remote', 'url': 'https://example.com/mcp'},
+        True,
+        _app(),
+    )
+    session._init_streamable_http_server = AsyncMock(
+        side_effect=ExceptionGroup('transport failed', [_http_status_error(405)])
+    )
+    session._init_sse_server = AsyncMock()
+
+    await session._init_remote_server()
+
+    session._init_streamable_http_server.assert_awaited_once()
+    session._init_sse_server.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_remote_transport_does_not_fallback_for_auth_http_status():
+    session = RuntimeMCPSession(
+        'remote',
+        {'uuid': 'srv-1', 'mode': 'remote', 'url': 'https://example.com/mcp'},
+        True,
+        _app(),
+    )
+    error = _http_status_error(403)
+    session._init_streamable_http_server = AsyncMock(side_effect=error)
+    session._init_sse_server = AsyncMock()
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await session._init_remote_server()
+
+    session._init_streamable_http_server.assert_awaited_once()
+    session._init_sse_server.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- Tightened MCP remote transport fallback so Streamable HTTP only falls back to legacy SSE for compatible HTTP 4xx initialization failures.
- Recursively inspects `ExceptionGroup` leaves so `httpx.HTTPStatusError` raised inside MCP SDK task groups is handled correctly.
- Keeps authentication failures such as 401/403 terminal instead of retrying as SSE and masking credential issues.
- Added focused unit coverage for 405 fallback and 403 non-fallback behavior.

## Why

Remote MCP auto-detection could surface SSE endpoints as Streamable HTTP failures when the SDK wrapped the HTTP status error. This makes the official Streamable HTTP -> legacy SSE compatibility path more precise without relying on URL suffix guessing.

## Validation

```bash
uv run pytest tests/unit_tests/provider/test_mcp_resources.py -q
```

Result: `10 passed`.