### PR TITLE
feat(provider): add TokenLab requester

### DIFF
--- a/src/langbot/pkg/provider/modelmgr/requesters/tokenlab.svg
+++ b/src/langbot/pkg/provider/modelmgr/requesters/tokenlab.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="TokenLab">
+  <rect width="64" height="64" rx="14" fill="#111827"/>
+  <path fill="#38bdf8" d="M17 14h30v8H36v28h-8V22H17z"/>
+  <path fill="#a7f3d0" d="M40 30h8v20H28v-8h12z"/>
+</svg>

--- a/src/langbot/pkg/provider/modelmgr/requesters/tokenlabchatcmpl.yaml
+++ b/src/langbot/pkg/provider/modelmgr/requesters/tokenlabchatcmpl.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: LLMAPIRequester
+metadata:
+  name: tokenlab-chat-completions
+  label:
+    en_US: TokenLab
+    zh_Hans: TokenLab
+  icon: tokenlab.svg
+spec:
+  litellm_provider: openai
+  config:
+  - name: base_url
+    label:
+      en_US: Base URL
+      zh_Hans: 基础 URL
+    type: string
+    required: true
+    default: https://api.tokenlab.sh/v1
+  - name: timeout
+    label:
+      en_US: Timeout
+      zh_Hans: 超时时间
+    type: integer
+    required: true
+    default: 120
+  alias: "tokenlab TokenLab gpt claude gemini deepseek qwen kimi minimax glm grok openai-compatible"
+  support_type:
+  - llm
+  provider_category: maas


### PR DESCRIPTION
## Summary
- add TokenLab as a built-in LLM API requester
- reuse the existing LiteLLM/OpenAI-compatible requester path with `https://api.tokenlab.sh/v1` as the default base URL
- include TokenLab search aliases for GPT, Claude, Gemini, DeepSeek, Qwen, Kimi, MiniMax, GLM, and Grok model families

## Validation
- `git diff --check`
- parsed `src/langbot/pkg/provider/modelmgr/requesters/tokenlabchatcmpl.yaml` with Python/PyYAML

TokenLab docs: https://docs.tokenlab.sh/



---

Supersedes #2325. The previous PR was closed while fixing contributor commit metadata; this replacement branch preserves the same scoped diff with commits authored by `hedging8563 <45883076+hedging8563@users.noreply.github.com>`.
