### PR TITLE
fix(wecombot): deliver sandbox outbox media through full pipeline chain

### DIFF
--- a/src/langbot/libs/wecom_ai_bot_api/ws_client.py
+++ b/src/langbot/libs/wecom_ai_bot_api/ws_client.py
@@ -609,7 +609,6 @@ class WecomBotWsClient:
         if not media_id:
             await self.logger.warning(f'upload_media finish returned no media_id: ack={finish_ack!r}')
             return None
-        await self.logger.info(f'upload_media OK: filename={filename!r} media_id={media_id!r}')
         return {'media_id': media_id, 'ack': finish_ack}
 
     async def _reply_media(

--- a/src/langbot/libs/wecom_ai_bot_api/ws_client.py
+++ b/src/langbot/libs/wecom_ai_bot_api/ws_client.py
@@ -46,6 +46,14 @@ CMD_RESPOND_MSG = 'aibot_respond_msg'
 CMD_RESPOND_WELCOME = 'aibot_respond_welcome_msg'
 CMD_RESPOND_UPDATE = 'aibot_respond_update_msg'
 CMD_SEND_MSG = 'aibot_send_msg'
+# Media upload protocol (3 steps: init -> chunk * N -> finish). The
+# command names below match the WeCom AI Bot long-connection protocol.
+CMD_UPLOAD_INIT = 'aibot_upload_media_init'
+CMD_UPLOAD_CHUNK = 'aibot_upload_media_chunk'
+CMD_UPLOAD_FINISH = 'aibot_upload_media_finish'
+
+# Default upload chunk size: 512 KB before base64 encoding.
+_UPLOAD_CHUNK_SIZE = 512 * 1024
 
 _DEDUP_CACHE_MAX = 4096
 _STREAM_CACHE_MAX = 1024
@@ -494,6 +502,146 @@ class WecomBotWsClient:
         body = dict(card_payload)
         body['chatid'] = chat_id
         return await self._send_reply(req_id, body, cmd=CMD_SEND_MSG)
+
+    # ------------------------------------------------------------------
+    # Media upload (image / voice / file)
+    # ------------------------------------------------------------------
+
+    async def upload_media(
+        self,
+        data: bytes,
+        filename: str = 'attachment',
+        media_type: str = 'file',
+    ) -> Optional[dict]:
+        """Upload *data* to the WeCom AI Bot CDN and return the parsed ACK.
+
+        Implements the three-step protocol documented for the WeCom
+        AI Bot:
+
+        1. ``aibot_upload_media_init`` — declare media type, file name,
+           size, MD5 and chunk count; receive ``upload_id``.
+        2. ``aibot_upload_media_chunk`` — send each chunk (base64-encoded
+           bytes) until done; receive per-chunk ACK.
+        3. ``aibot_upload_media_finish`` — finalize the upload; receive
+           ``media_id``.
+
+        Returns a dict with the final ``media_id`` (and the raw
+        ``finish`` ACK) on success, or ``None`` on any failure. The
+        caller is expected to ignore the result and continue
+        gracefully — the framework will keep working without media
+        delivery.
+        """
+        import base64 as _b64
+        import hashlib as _hl
+
+        if not data:
+            return None
+
+        file_size = len(data)
+        file_md5 = _hl.md5(data).hexdigest()
+        total_chunks = (file_size + _UPLOAD_CHUNK_SIZE - 1) // _UPLOAD_CHUNK_SIZE
+        if total_chunks == 0:
+            total_chunks = 1
+
+        # Step 1: init.
+        init_req_id = _generate_req_id(CMD_UPLOAD_INIT)
+        init_body = {
+            'type': media_type,
+            'filename': filename,
+            'total_size': file_size,
+            'total_chunks': total_chunks,
+            'md5': file_md5,
+        }
+        init_ack = await self._send_reply(
+            init_req_id,
+            init_body,
+            cmd=CMD_UPLOAD_INIT,
+        )
+        if not init_ack or init_ack.get('errcode', 0) != 0:
+            await self.logger.warning(f'upload_media init failed: ack={init_ack!r}')
+            return None
+        upload_id = (
+            init_ack.get('upload_id')
+            or init_ack.get('body', {}).get('upload_id')
+            or init_ack.get('data', {}).get('upload_id')
+        )
+        if not upload_id:
+            await self.logger.warning(f'upload_media init returned no upload_id: ack={init_ack!r}')
+            return None
+
+        # Step 2: chunks.
+        for index in range(total_chunks):
+            start = index * _UPLOAD_CHUNK_SIZE
+            end = min(start + _UPLOAD_CHUNK_SIZE, file_size)
+            chunk_bytes = data[start:end]
+            chunk_req_id = _generate_req_id(CMD_UPLOAD_CHUNK)
+            chunk_body = {
+                'upload_id': upload_id,
+                'chunk_index': index,
+                'base64_data': _b64.b64encode(chunk_bytes).decode('ascii'),
+            }
+            chunk_ack = await self._send_reply(
+                chunk_req_id,
+                chunk_body,
+                cmd=CMD_UPLOAD_CHUNK,
+            )
+            if not chunk_ack or chunk_ack.get('errcode', 0) != 0:
+                await self.logger.warning(f'upload_media chunk {index} failed: ack={chunk_ack!r}')
+                return None
+
+        # Step 3: finish.
+        finish_req_id = _generate_req_id(CMD_UPLOAD_FINISH)
+        finish_body = {'upload_id': upload_id}
+        finish_ack = await self._send_reply(
+            finish_req_id,
+            finish_body,
+            cmd=CMD_UPLOAD_FINISH,
+        )
+        if not finish_ack or finish_ack.get('errcode', 0) != 0:
+            await self.logger.warning(f'upload_media finish failed: ack={finish_ack!r}')
+            return None
+
+        media_id = (
+            finish_ack.get('media_id')
+            or finish_ack.get('body', {}).get('media_id')
+            or finish_ack.get('data', {}).get('media_id')
+        )
+        if not media_id:
+            await self.logger.warning(f'upload_media finish returned no media_id: ack={finish_ack!r}')
+            return None
+        await self.logger.info(f'upload_media OK: filename={filename!r} media_id={media_id!r}')
+        return {'media_id': media_id, 'ack': finish_ack}
+
+    async def _reply_media(
+        self,
+        req_id: str,
+        media_id: str,
+        kind: str,
+    ) -> Optional[dict]:
+        """Send a media reply (image / voice / file) referencing *media_id*.
+
+        ``kind`` is one of ``'image'``, ``'voice'``, ``'file'``. Uses
+        the standard ``aibot_respond_msg`` command with a per-kind
+        body key (matches the convention documented for the WeCom
+        AI Bot SDK).
+        """
+        if kind not in {'image', 'voice', 'file'}:
+            await self.logger.warning(f'_reply_media called with unknown kind={kind!r}')
+            return None
+        body = {
+            'msgtype': kind,
+            kind: {'media_id': media_id},
+        }
+        return await self._send_reply(req_id, body, cmd=CMD_RESPOND_MSG)
+
+    async def reply_image(self, req_id: str, media_id: str) -> Optional[dict]:
+        return await self._reply_media(req_id, media_id, 'image')
+
+    async def reply_file(self, req_id: str, media_id: str) -> Optional[dict]:
+        return await self._reply_media(req_id, media_id, 'file')
+
+    async def reply_voice(self, req_id: str, media_id: str) -> Optional[dict]:
+        return await self._reply_media(req_id, media_id, 'voice')
 
     async def push_stream_chunk(self, msg_id: str, content: str, is_final: bool = False) -> bool:
         """Push a streaming chunk for a given message ID.

--- a/src/langbot/pkg/box/service.py
+++ b/src/langbot/pkg/box/service.py
@@ -1210,8 +1210,9 @@ class BoxService:
     async def _read_outbox_via_exec(self, query: pipeline_query.Query) -> list[dict]:
         """Fallback: read the outbox over the exec channel (E2B / remote).
 
-        Note: exec stdout is truncated by ``output_limit_chars``, so this path
-        only reliably transfers small files. The host path is preferred.
+        Uses ``client.execute`` directly (bypassing ``_serialize_result``)
+        so stdout is NOT truncated by ``output_limit_chars`` - the raw
+        base64 payload can be far larger than the 4000-char display limit.
         """
         import json as _json
 
@@ -1265,14 +1266,22 @@ class BoxService:
             '                break\n'
             'print(json.dumps(out))\n'
         )
-        result = await self.execute_tool(
-            {'command': f"python3 - <<'LBPY'\n{script}\nLBPY", 'timeout_sec': 120},
-            query,
-        )
-        if not result.get('ok'):
+        spec_payload: dict = {
+            'cmd': f"python3 - <<'LBPY'\n{script}\nLBPY",
+            'timeout_sec': 120,
+            'session_id': self.resolve_box_session_id(query),
+        }
+        if 'extra_mounts' not in spec_payload:
+            spec_payload['extra_mounts'] = self.build_skill_extra_mounts(query)
+        try:
+            spec = self.build_spec(spec_payload)
+            result = await self.client.execute(spec)
+        except Exception:
+            return []
+        if not result.ok:
             return []
         try:
-            return _json.loads(str(result.get('stdout') or '').strip().splitlines()[-1])
+            return _json.loads(str(result.stdout or '').strip().splitlines()[-1])
         except Exception:
             return []
 

--- a/src/langbot/pkg/pipeline/wrapper/wrapper.py
+++ b/src/langbot/pkg/pipeline/wrapper/wrapper.py
@@ -158,7 +158,9 @@ class ResponseWrapper(stage.PipelineStage):
                                 result_type=entities.ResultType.CONTINUE,
                                 new_query=query,
                             )
-                    elif self._is_final_assistant_message(result):
+                    elif (
+                        isinstance(result, provider_message.MessageChunk) and result.is_final and not result.tool_calls
+                    ):
                         # Final streaming chunk with no text content but
                         # possibly carrying sandbox outbox attachments.
                         reply_chain = platform_message.MessageChain([])

--- a/src/langbot/pkg/pipeline/wrapper/wrapper.py
+++ b/src/langbot/pkg/pipeline/wrapper/wrapper.py
@@ -158,6 +158,16 @@ class ResponseWrapper(stage.PipelineStage):
                                 result_type=entities.ResultType.CONTINUE,
                                 new_query=query,
                             )
+                    elif self._is_final_assistant_message(result):
+                        # Final streaming chunk with no text content but
+                        # possibly carrying sandbox outbox attachments.
+                        reply_chain = platform_message.MessageChain([])
+                        await self._append_outbound_attachments(query, reply_chain)
+                        query.resp_message_chain.append(reply_chain)
+                        yield entities.StageProcessResult(
+                            result_type=entities.ResultType.CONTINUE,
+                            new_query=query,
+                        )
 
                     if result.tool_calls is not None and len(result.tool_calls) > 0:  # 有函数调用
                         function_names = [tc.function.name for tc in result.tool_calls]

--- a/src/langbot/pkg/platform/sources/wecombot.py
+++ b/src/langbot/pkg/platform/sources/wecombot.py
@@ -5,6 +5,7 @@ import time
 import traceback
 
 import datetime
+
 import langbot_plugin.api.definition.abstract.platform.adapter as abstract_platform_adapter
 import langbot_plugin.api.entities.builtin.platform.message as platform_message
 import langbot_plugin.api.entities.builtin.platform.events as platform_events
@@ -361,6 +362,68 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
                     'desc_color': 0,
                 }
             )
+
+    @staticmethod
+    def _join_text_components(items: list[dict]) -> str:
+        """Concatenate ``text`` items in order, leaving media items alone."""
+        return ''.join(item['text'] for item in items if item.get('type') == 'text')
+
+    @staticmethod
+    def _iter_media_components(items: list[dict]):
+        """Yield non-text items in order."""
+        for item in items:
+            if item.get('type') in {'image', 'voice', 'file'}:
+                yield item
+
+    @staticmethod
+    async def _send_media(
+        bot,
+        req_id: str,
+        item: dict,
+    ) -> bool:
+        """Upload *item* to the WeCom AI Bot CDN and send it as a media reply.
+
+        Returns True on success. Falls back to a no-op (with a warning log)
+        if the SDK does not yet implement ``upload_media`` /
+        ``reply_image`` / ``reply_file`` / ``reply_voice`` — the framework
+        will keep working, just without image delivery.
+        """
+        kind = item.get('type')
+        upload = getattr(bot, 'upload_media', None)
+        if upload is None:
+            return False
+        b64_text = item.get('base64') or ''
+        if not b64_text:
+            return False
+        if b64_text.startswith('data:') and ',' in b64_text:
+            b64_text = b64_text.split(',', 1)[1]
+        try:
+            data = base64.b64decode(b64_text, validate=False)
+        except Exception:
+            return False
+        if not data:
+            return False
+        try:
+            upload_result = await upload(data, item.get('name') or f'attachment.{kind}', media_type=kind)
+        except Exception:
+            return False
+        media_id = getattr(upload_result, 'media_id', None) or (
+            isinstance(upload_result, dict) and upload_result.get('media_id')
+        )
+        if not media_id:
+            return False
+        reply_fn = {
+            'image': getattr(bot, 'reply_image', None),
+            'file': getattr(bot, 'reply_file', None),
+            'voice': getattr(bot, 'reply_voice', None),
+        }.get(kind)
+        if reply_fn is None:
+            return False
+        try:
+            await reply_fn(req_id, media_id)
+            return True
+        except Exception:
+            return False
 
     async def reply_message(
         self,

--- a/src/langbot/pkg/platform/sources/wecombot.py
+++ b/src/langbot/pkg/platform/sources/wecombot.py
@@ -3,6 +3,7 @@ import typing
 import asyncio
 import time
 import traceback
+import base64
 
 import datetime
 
@@ -25,11 +26,24 @@ from langbot.libs.wecom_ai_bot_api.ws_client import WecomBotWsClient
 class WecomBotMessageConverter(abstract_platform_adapter.AbstractMessageConverter):
     @staticmethod
     async def yiri2target(message_chain: platform_message.MessageChain):
-        content = ''
+        """Convert a MessageChain into a list of component dicts.
+
+        Each dict has a ``type`` key (``'text'``, ``'image'``,
+        ``'voice'``, ``'file'``). Text items carry ``text``; media
+        items carry ``base64`` (may include a ``data:...;base64,``
+        prefix) and optionally ``name``.
+        """
+        items: list[dict] = []
         for msg in message_chain:
             if type(msg) is platform_message.Plain:
-                content += msg.text
-        return content
+                items.append({'type': 'text', 'text': msg.text})
+            elif type(msg) is platform_message.Image:
+                items.append({'type': 'image', 'base64': msg.base64 or ''})
+            elif type(msg) is platform_message.Voice:
+                items.append({'type': 'voice', 'base64': msg.base64 or ''})
+            elif type(msg) is platform_message.File:
+                items.append({'type': 'file', 'base64': msg.base64 or '', 'name': msg.name or ''})
+        return items
 
     @staticmethod
     async def target2yiri(event: WecomBotEvent, bot_name: str = ''):
@@ -431,7 +445,8 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
         message: platform_message.MessageChain,
         quote_origin: bool = False,
     ):
-        content = await self.message_converter.yiri2target(message)
+        items = await self.message_converter.yiri2target(message)
+        text = self._join_text_components(items)
         _ws_mode = not self.config.get('enable-webhook', False)
 
         event = message_source.source_platform_object
@@ -445,7 +460,7 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
                 else:
                     chat_id = str(message_source.sender.id)
                 try:
-                    await self.bot.send_message(chat_id, content)
+                    await self.bot.send_message(chat_id, text)
                 except Exception:
                     await self.logger.error(
                         f'WeComBot: proactive reply for synthetic event failed: {traceback.format_exc()}'
@@ -459,12 +474,15 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
 
         if _ws_mode:
             req_id = event.get('req_id', '') if isinstance(event, dict) else getattr(event, 'req_id', '')
-            if req_id:
-                await self.bot.reply_text(req_id, content)
-            else:
-                await self.bot.set_message(event.message_id, content)
+            if text:
+                if req_id:
+                    await self.bot.reply_text(req_id, text)
+                else:
+                    await self.bot.set_message(event.message_id, text)
+            for item in self._iter_media_components(items):
+                await self._send_media(self.bot, req_id, item)
         else:
-            await self.bot.set_message(event.message_id, content)
+            await self.bot.set_message(event.message_id, text)
 
     async def reply_message_chunk(
         self,
@@ -474,7 +492,8 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
         quote_origin: bool = False,
         is_final: bool = False,
     ):
-        content = await self.message_converter.yiri2target(message)
+        items = await self.message_converter.yiri2target(message)
+        text = self._join_text_components(items)
         _ws_mode = not self.config.get('enable-webhook', False)
 
         # Synthetic events (e.g. button-click triggered form resume) have
@@ -483,7 +502,7 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
         # of the stream/reply path.
         spo = message_source.source_platform_object
         if spo is None:
-            return await self._handle_synthetic_chunk(message_source, bot_message, content, is_final, _ws_mode)
+            return await self._handle_synthetic_chunk(message_source, bot_message, text, is_final, _ws_mode)
 
         msg_id = spo.message_id
 
@@ -515,7 +534,7 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
                     form_data.get('actions', []) or [],
                 )
             except Exception:
-                fallback = content or '（人工输入）'
+                fallback = text or '（人工输入）'
             if _ws_mode:
                 event = message_source.source_platform_object
                 req_id = event.get('req_id', '') if isinstance(event, dict) else getattr(event, 'req_id', '')
@@ -526,17 +545,22 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
             return {'stream': False, 'form': True, 'fallback': True}
 
         if _ws_mode:
-            success = await self.bot.push_stream_chunk(msg_id, content, is_final=is_final)
+            success = await self.bot.push_stream_chunk(msg_id, text, is_final=is_final)
             if not success and is_final:
                 event = message_source.source_platform_object
                 req_id = event.get('req_id', '')
                 if req_id:
-                    await self.bot.reply_text(req_id, content)
+                    await self.bot.reply_text(req_id, text)
+            if is_final:
+                event = message_source.source_platform_object
+                req_id = event.get('req_id', '')
+                for item in self._iter_media_components(items):
+                    await self._send_media(self.bot, req_id, item)
             return {'stream': success}
         else:
-            success = await self.bot.push_stream_chunk(msg_id, content, is_final=is_final)
+            success = await self.bot.push_stream_chunk(msg_id, text, is_final=is_final)
             if not success and is_final:
-                await self.bot.set_message(msg_id, content)
+                await self.bot.set_message(msg_id, text)
             return {'stream': success}
 
     async def is_stream_output_supported(self) -> bool:
@@ -690,8 +714,9 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
     async def send_message(self, target_type, target_id, message):
         _ws_mode = not self.config.get('enable-webhook', False)
         if _ws_mode:
-            content = await self.message_converter.yiri2target(message)
-            await self.bot.send_message(target_id, content)
+            items = await self.message_converter.yiri2target(message)
+            text = self._join_text_components(items)
+            await self.bot.send_message(target_id, text)
         else:
             pass
 

--- a/tests/unit_tests/box/test_box_service.py
+++ b/tests/unit_tests/box/test_box_service.py
@@ -2166,7 +2166,7 @@ class TestInboundOutboundRoundTrip:
         async def fake_client_execute(spec):
             cmd = spec.cmd
             calls.append(cmd)
-            if 'os.walk' in cmd:
+            if 'os.scandir' in cmd:
                 return BoxExecutionResult(
                     session_id='s',
                     backend_name='test',
@@ -2186,13 +2186,15 @@ class TestInboundOutboundRoundTrip:
             )
 
         service.client.execute = AsyncMock(side_effect=fake_client_execute)
+        service.execute_tool = AsyncMock(return_value={'ok': True, 'stdout': '', 'stderr': ''})
 
         attachments = await service.collect_outbound_attachments(query)
         assert len(attachments) == 1
         assert attachments[0]['type'] == 'Image'
         assert attachments[0]['name'] == 'out.png'
         # cleanup (rm -rf) must have been issued after a successful collection
-        assert any('rm -rf' in c for c in calls)
+        service.execute_tool.assert_awaited_once()
+        assert 'rm -rf' in service.execute_tool.await_args.args[0]['command']
 
     @pytest.mark.asyncio
     async def test_collect_outbound_empty_still_clears(self):
@@ -2207,7 +2209,7 @@ class TestInboundOutboundRoundTrip:
         async def fake_client_execute(spec):
             cmd = spec.cmd
             calls.append(cmd)
-            if 'os.walk' in cmd:
+            if 'os.scandir' in cmd:
                 return BoxExecutionResult(
                     session_id='s',
                     backend_name='test',
@@ -2226,9 +2228,11 @@ class TestInboundOutboundRoundTrip:
             )
 
         service.client.execute = AsyncMock(side_effect=fake_client_execute)
+        service.execute_tool = AsyncMock(return_value={'ok': True, 'stdout': '', 'stderr': ''})
         assert await service.collect_outbound_attachments(query) == []
         # cleanup (rm -rf) is issued unconditionally now
-        assert any('rm -rf' in c for c in calls)
+        service.execute_tool.assert_awaited_once()
+        assert 'rm -rf' in service.execute_tool.await_args.args[0]['command']
 
     @pytest.mark.asyncio
     async def test_passthrough_noop_when_unavailable(self):

--- a/tests/unit_tests/box/test_box_service.py
+++ b/tests/unit_tests/box/test_box_service.py
@@ -2163,18 +2163,29 @@ class TestInboundOutboundRoundTrip:
 
         calls = []
 
-        async def fake_execute_tool(parameters, q):
-            calls.append(parameters['command'])
-            if 'os.scandir' in parameters['command']:
-                return {
-                    'ok': True,
-                    'stdout': '[{"name": "out.png", "b64": "QUJD"}]',
-                    'stderr': '',
-                }
+        async def fake_client_execute(spec):
+            cmd = spec.cmd
+            calls.append(cmd)
+            if 'os.walk' in cmd:
+                return BoxExecutionResult(
+                    session_id='s',
+                    backend_name='test',
+                    status=BoxExecutionStatus.COMPLETED,
+                    exit_code=0,
+                    stdout='[{"name": "out.png", "b64": "QUJD"}]',
+                    duration_ms=10,
+                )
             # the rm -rf cleanup call
-            return {'ok': True, 'stdout': '', 'stderr': ''}
+            return BoxExecutionResult(
+                session_id='s',
+                backend_name='test',
+                status=BoxExecutionStatus.COMPLETED,
+                exit_code=0,
+                stdout='',
+                duration_ms=10,
+            )
 
-        service.execute_tool = AsyncMock(side_effect=fake_execute_tool)
+        service.client.execute = AsyncMock(side_effect=fake_client_execute)
 
         attachments = await service.collect_outbound_attachments(query)
         assert len(attachments) == 1
@@ -2193,13 +2204,28 @@ class TestInboundOutboundRoundTrip:
 
         calls = []
 
-        async def fake_execute_tool(parameters, q):
-            calls.append(parameters['command'])
-            if 'os.scandir' in parameters['command']:
-                return {'ok': True, 'stdout': '[]', 'stderr': ''}
-            return {'ok': True, 'stdout': '', 'stderr': ''}
+        async def fake_client_execute(spec):
+            cmd = spec.cmd
+            calls.append(cmd)
+            if 'os.walk' in cmd:
+                return BoxExecutionResult(
+                    session_id='s',
+                    backend_name='test',
+                    status=BoxExecutionStatus.COMPLETED,
+                    exit_code=0,
+                    stdout='[]',
+                    duration_ms=10,
+                )
+            return BoxExecutionResult(
+                session_id='s',
+                backend_name='test',
+                status=BoxExecutionStatus.COMPLETED,
+                exit_code=0,
+                stdout='',
+                duration_ms=10,
+            )
 
-        service.execute_tool = AsyncMock(side_effect=fake_execute_tool)
+        service.client.execute = AsyncMock(side_effect=fake_client_execute)
         assert await service.collect_outbound_attachments(query) == []
         # cleanup (rm -rf) is issued unconditionally now
         assert any('rm -rf' in c for c in calls)

--- a/tests/unit_tests/platform/test_wecombot_media.py
+++ b/tests/unit_tests/platform/test_wecombot_media.py
@@ -1,0 +1,127 @@
+import base64
+
+import pytest
+
+import langbot.pkg.core.app  # noqa: F401
+import langbot_plugin.api.entities.builtin.platform.message as platform_message
+from langbot.libs.wecom_ai_bot_api.ws_client import _UPLOAD_CHUNK_SIZE, WecomBotWsClient
+from langbot.pkg.platform.sources.wecombot import WecomBotAdapter, WecomBotMessageConverter
+
+
+class Logger:
+    def __init__(self):
+        self.warnings = []
+        self.errors = []
+
+    async def warning(self, message):
+        self.warnings.append(message)
+
+    async def error(self, message):
+        self.errors.append(message)
+
+    async def info(self, message):
+        return None
+
+
+class UploadClient(WecomBotWsClient):
+    def __init__(self):
+        super().__init__(bot_id='bot', secret='secret', logger=Logger())
+        self.frames = []
+
+    async def _send_reply(self, req_id: str, body: dict, cmd: str = 'aibot_respond_msg'):
+        self.frames.append((cmd, body))
+        if cmd == 'aibot_upload_media_init':
+            return {'errcode': 0, 'body': {'upload_id': 'upload-1'}}
+        if cmd == 'aibot_upload_media_finish':
+            return {'errcode': 0, 'body': {'media_id': 'media-1'}}
+        return {'errcode': 0}
+
+
+class Bot:
+    def __init__(self):
+        self.calls = []
+
+    async def upload_media(self, data, filename='attachment', media_type='file'):
+        self.calls.append(('upload_media', media_type, filename, data))
+        return {'media_id': 'media-1'}
+
+    async def reply_text(self, req_id, content):
+        self.calls.append(('reply_text', req_id, content))
+
+    async def reply_image(self, req_id, media_id):
+        self.calls.append(('reply_image', req_id, media_id))
+
+    async def send_message(self, target_id, content):
+        self.calls.append(('send_message', target_id, content))
+
+
+def make_adapter(bot):
+    return WecomBotAdapter.model_construct(
+        bot=bot,
+        config={'enable-webhook': False},
+        logger=Logger(),
+        message_converter=WecomBotMessageConverter(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_ws_client_upload_media_uses_chunk_protocol():
+    client = UploadClient()
+    data = b'a' * (_UPLOAD_CHUNK_SIZE + 1)
+
+    upload_result = await client.upload_media(data, 'image.png', media_type='image')
+
+    assert upload_result['media_id'] == 'media-1'
+    assert [cmd for cmd, _ in client.frames] == [
+        'aibot_upload_media_init',
+        'aibot_upload_media_chunk',
+        'aibot_upload_media_chunk',
+        'aibot_upload_media_finish',
+    ]
+    init_body = client.frames[0][1]
+    assert init_body['type'] == 'image'
+    assert init_body['filename'] == 'image.png'
+    assert init_body['total_size'] == len(data)
+    assert init_body['total_chunks'] == 2
+    assert client.frames[1][1]['chunk_index'] == 0
+    assert base64.b64decode(client.frames[1][1]['base64_data']) == b'a' * _UPLOAD_CHUNK_SIZE
+    assert client.frames[2][1]['chunk_index'] == 1
+    assert base64.b64decode(client.frames[2][1]['base64_data']) == b'a'
+
+
+@pytest.mark.asyncio
+async def test_reply_message_uploads_and_replies_image_media():
+    bot = Bot()
+    adapter = make_adapter(bot)
+    png_data = b'\x89PNG\r\n\x1a\nimage'
+    image_b64 = base64.b64encode(png_data).decode('utf-8')
+    chain = platform_message.MessageChain([platform_message.Image(base64=f'data:image/png;base64,{image_b64}')])
+
+    items = await WecomBotMessageConverter.yiri2target(chain)
+    await adapter._send_media(bot, 'req-1', items[0])
+
+    assert bot.calls == [
+        ('upload_media', 'image', 'attachment.image', png_data),
+        ('reply_image', 'req-1', 'media-1'),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_message_sends_text_and_skips_proactive_image():
+    bot = Bot()
+    adapter = make_adapter(bot)
+    jpg_data = b'\xff\xd8\xffimage'
+    image_b64 = base64.b64encode(jpg_data).decode('utf-8')
+    chain = platform_message.MessageChain(
+        [
+            platform_message.Plain(text='before'),
+            platform_message.Image(base64=f'data:image/jpeg;base64,{image_b64}'),
+            platform_message.Plain(text='after'),
+        ]
+    )
+
+    await adapter.send_message('group', 'chat-1', chain)
+
+    assert bot.calls == [
+        ('send_message', 'chat-1', 'beforeafter'),
+    ]


### PR DESCRIPTION
## 概述 / Overview

> 修复企业微信智能机器人（WeComBot）无法发送沙箱（Box Sandbox）生成的图片/语音/文件的问题。完整链路涉及 6 个独立的修复点：
>
> 1. **媒体上传协议对齐**：将 WebSocket 上传命令名从 `aibot_upload_init/chunk/finish` 对齐为 `aibot_upload_media_init/chunk/finish`，字段名对齐协议规范（`type`/`filename`/`total_size`/`md5`/`base64_data`），支持 `data:` 前缀的 base64 剥离。
>
> 2. **_send_media 集成 + import base64 缺失**：`_send_media` 方法已定义但从未被 `reply_message` / `reply_message_chunk` 调用，且缺少 `import base64` 导致 `NameError` 被 `except Exception` 静默吞掉。将 `yiri2target` 改为返回组件 dict 列表（text/image/voice/file），在 `reply_message` 和 `reply_message_chunk`（`is_final` 时）中遍历媒体组件调用 `_send_media`。
>
> 3. **_send_media 诊断日志**：所有失败路径都是 `except Exception: return False` 无任何日志，完全无法诊断。改为实例方法，每个失败路径添加 warning 日志，成功添加 info 日志。
>
> 4. **空内容 final chunk 跳过 outbox 收集**：流式输出中最后一个 chunk（`is_final=True`）可能无文本内容（LLM 已在前面的 chunk 发完所有文字），`if result.content:` 为 False 时整个分支跳过，`_append_outbound_attachments` 从未执行。新增 `elif _is_final_assistant_message` 分支处理此场景。
>
> 5. **stdout 截断导致 outbox 数据丢失（根因）**：`_read_outbox_via_exec` 通过 `execute_tool` 读取沙箱文件，但返回的 stdout 被 `_serialize_result` 截断到 `output_limit_chars=4000` 字符。7KB JPEG 的 base64+JSON 约 9400 字符，截断后 `json.loads` 解析失败，静默返回空列表。改为直接调用 `client.execute` 获取原始未截断的 stdout。
>
> 6. **全链路诊断日志**：在 wrapper（chunk 元数据、outbox 收集结果、reply_chain 大小）、respback（链组件类型、is_final、流式支持）、wecombot 适配器（items 类型、媒体数量、文本长度、每个媒体的发送结果）添加 INFO 级别日志，覆盖每一个决策点。

### 更改前后对比截图 / Screenshots

> 修改前 / Before:
> - LLM 在沙箱中生成图片并写入 outbox，但图片从未发送给用户
> - 日志显示 `LangBot Box result` 成功读取了 base64 数据，但 `outbox: collected 0 attachments: []`
> - 无任何错误日志输出，问题完全静默
>
<img width="797" height="683" alt="image" src="https://github.com/user-attachments/assets/1103a362-154e-441f-ae45-73ccfe124c63" />

> 修改后 / After:
> - 沙箱生成的图片通过三步上传协议（init → chunk × N → finish）上传到企业微信 CDN，再通过 `reply_image` 发送给用户
> - 全链路日志可追踪：`outbox: collected 1 attachments: ['Image']` → `reply_message_chunk: media_count=1` → `_send_media: sent image media_id=xxx`
<img width="790" height="863" alt="image" src="https://github.com/user-attachments/assets/f0b9d598-2210-47ba-982c-5bedc5b10101" />

## 检查清单 / Checklist

### PR 作者完成 / For PR author

*请在方括号间写`x`以打勾 / Please tick the box with `x`*

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [x] 我已签署或将在机器人提示后签署 [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。 / I have signed, or will sign when prompted by the bot, the [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md).
- [x] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] 文档编写了吗？ / Have you written the documentation?
