### PR TITLE
fix(provider): strip think tags for MiniMax-M3 and other OpenAI-compatible models

### DIFF
--- a/src/langbot/pkg/provider/modelmgr/requesters/litellmchat.py
+++ b/src/langbot/pkg/provider/modelmgr/requesters/litellmchat.py
@@ -24,7 +24,8 @@ class _ThinkStripState:
     buffer for the next call.
     """
 
-    _OPEN_TAG: str = '</think>'
+    _OPEN_TAG: str = '<think>'
+    _CLOSE_TAG: str = '</think>'
     _LEGACY_OPEN: str = 'CRETIRE_REASONING_BEGINk'
     _LEGACY_CLOSE: str = 'CRETIRE_REASONING_ENDk'
 

--- a/src/langbot/pkg/provider/modelmgr/requesters/litellmchat.py
+++ b/src/langbot/pkg/provider/modelmgr/requesters/litellmchat.py
@@ -14,133 +14,148 @@ import langbot_plugin.api.entities.builtin.provider.message as provider_message
 
 
 class _ThinkStripState:
-    """Stateful filter that drops ```` think blocks across chunk boundaries.
+    """Stateful filter that drops think blocks across chunks."""
 
-    The think tag (and the legacy CRETIRE_* marker) can straddle two or
-    more streaming chunks.  A naive per-chunk regex either fails to match
-    (when split mid-tag) or leaks the tag into user-visible output.  This
-    state machine tracks the longest suffix of the consumed input that is
-    also a prefix of any known tag, and keeps that suffix in an internal
-    buffer for the next call.
-    """
-
-    _OPEN_TAG: str = '<think>'
-    _CLOSE_TAG: str = '</think>'
-    _LEGACY_OPEN: str = 'CRETIRE_REASONING_BEGINk'
-    _LEGACY_CLOSE: str = 'CRETIRE_REASONING_ENDk'
+    _THINK_OPEN = '<think>'
+    _THINK_CLOSE = '</think>'
+    _LEGACY_OPEN = 'CRETIRE_REASONING_BEGINk'
+    _LEGACY_CLOSE = 'CRETIRE_REASONING_ENDk'
 
     def __init__(self) -> None:
-        self._tags: tuple[str, ...] = (
-            self._OPEN_TAG,
-            self._CLOSE_TAG,
-            self._LEGACY_OPEN,
-            self._LEGACY_CLOSE,
+        self._pairs: tuple[tuple[str, str], ...] = (
+            (self._THINK_OPEN, self._THINK_CLOSE),
+            (self._LEGACY_OPEN, self._LEGACY_CLOSE),
         )
-        self._max_tag_len: int = max(len(t) for t in self._tags)
-        self._buf: str = ''
-        self._buf_inside: bool = False
+        self._open_tags = tuple(open_tag for open_tag, _close_tag in self._pairs)
+        self._buf = ''
+        self._close_tag: str | None = None
+        self._pending_initial = True
 
     def feed(self, chunk: str) -> str:
-        """Feed a streaming delta; return the portion that should be emitted."""
+        """Feed a streaming delta and return user-visible content."""
         if not chunk:
             return chunk
 
-        if self._buf_inside:
-            text = self._buf + chunk
-            for close_tag in (self._CLOSE_TAG, self._LEGACY_CLOSE):
-                idx = text.find(close_tag)
-                if idx != -1:
-                    self._buf = ''
-                    self._buf_inside = False
-                    return self._process(text[idx + len(close_tag) :])
-            keep = 0
-            for tag in (self._CLOSE_TAG, self._LEGACY_CLOSE):
-                _, k = self._split_for_close_prefix(text, 0, tag)
-                if k > keep:
-                    keep = k
-            self._buf = text[len(text) - keep :]
-            return ''
-
-        return self._process(chunk)
-
-    def _process(self, chunk: str) -> str:
         text = self._buf + chunk
+        if self._close_tag is not None:
+            return self._consume_think_body(text)
 
-        out: list[str] = []
-        i = 0
-        n = len(text)
-        while i < n:
-            open_idx, open_tag = self._find_open(text, i)
-            if open_idx == -1:
-                emit_end, _keep = self._split_for_tag_prefix(text, i)
-                out.append(text[i:emit_end])
-                self._buf = text[emit_end:]
-                self._buf_inside = False
-                return ''.join(out)
-
-            if open_idx > i:
-                out.append(text[i:open_idx])
-            block_start = open_idx + len(open_tag)
-            close_tag = self._LEGACY_CLOSE if open_tag == self._LEGACY_OPEN else self._CLOSE_TAG
-            close_idx = text.find(close_tag, block_start)
-            if close_idx == -1:
-                emit_end, _keep = self._split_for_close_prefix(text, block_start, close_tag)
-                self._buf = text[emit_end:]
-                self._buf_inside = True
-                return ''.join(out)
-            i = close_idx + len(close_tag)
-
-        emit_end, _keep = self._split_for_tag_prefix(text, i)
-        out.append(text[i:emit_end])
-        self._buf = text[emit_end:]
-        self._buf_inside = False
-        return ''.join(out)
+        return self._process_visible_text(text)
 
     def flush(self) -> str:
-        """Release any text still held in the internal buffer."""
-        pending, self._buf = self._buf, ''
-        inside, self._buf_inside = self._buf_inside, False
-        if inside:
+        """Release buffered visible content when the stream ends."""
+        if self._close_tag is not None:
+            self._buf = ''
+            self._close_tag = None
             return ''
+
+        pending, self._buf = self._buf, ''
+        self._close_tag = None
         return pending
 
-    def _find_open(self, text: str, start: int) -> tuple[int, str]:
+    def _consume_think_body(self, text: str) -> str:
+        close_tag = self._close_tag
+        if close_tag is None:
+            return text
+
+        close_idx = text.find(close_tag)
+        if close_idx != -1:
+            self._close_tag = None
+            self._buf = ''
+            self._pending_initial = False
+            return self._process_visible_text(text[close_idx + len(close_tag) :])
+
+        self._buf = self._close_prefix(text, close_tag)
+        return ''
+
+    def _process_visible_text(self, text: str) -> str:
+        out: list[str] = []
+        index = 0
+
+        while index < len(text):
+            if self._pending_initial:
+                open_idx, open_tag, close_tag = self._find_next_open(text, index)
+                orphan_close_idx, orphan_close_tag = self._find_next_close(text, index)
+
+                if orphan_close_idx != -1 and (open_idx == -1 or orphan_close_idx < open_idx):
+                    self._pending_initial = False
+                    index = orphan_close_idx + len(orphan_close_tag)
+                    continue
+
+                if open_idx == -1:
+                    self._buf = text[index:]
+                    return ''.join(out)
+
+                if open_idx > index:
+                    self._pending_initial = False
+                    out.append(text[index:open_idx])
+                    index = open_idx
+                    continue
+
+            open_idx, open_tag, close_tag = self._find_next_open(text, index)
+            if open_idx == -1:
+                emit_end = self._visible_emit_end(text, index)
+                out.append(text[index:emit_end])
+                if emit_end > index:
+                    self._pending_initial = False
+                self._buf = text[emit_end:]
+                return ''.join(out)
+
+            out.append(text[index:open_idx])
+            if open_idx > index:
+                self._pending_initial = False
+            body_start = open_idx + len(open_tag)
+            close_idx = text.find(close_tag, body_start)
+            if close_idx == -1:
+                self._close_tag = close_tag
+                self._buf = self._close_prefix(text[body_start:], close_tag)
+                return ''.join(out)
+
+            self._pending_initial = False
+            index = close_idx + len(close_tag)
+
+        self._buf = ''
+        return ''.join(out)
+
+    def _find_next_open(self, text: str, start: int) -> tuple[int, str, str]:
         best_idx = -1
-        best_tag = ''
-        for tag in (self._OPEN_TAG, self._LEGACY_OPEN):
-            idx = text.find(tag, start)
+        best_open = ''
+        best_close = ''
+        for open_tag, close_tag in self._pairs:
+            idx = text.find(open_tag, start)
             if idx != -1 and (best_idx == -1 or idx < best_idx):
                 best_idx = idx
-                best_tag = tag
-        return best_idx, best_tag
+                best_open = open_tag
+                best_close = close_tag
+        return best_idx, best_open, best_close
 
-    def _split_for_tag_prefix(self, text: str, start: int) -> tuple[int, int]:
-        suffix = text[start:]
-        best_keep = 0
-        for tag in (self._OPEN_TAG, self._LEGACY_OPEN):
-            idx = suffix.find(tag)
-            if idx != -1:
-                candidate = len(suffix) - idx
-                if candidate > best_keep:
-                    best_keep = candidate
-        if best_keep == 0:
-            limit = min(len(suffix), self._max_tag_len - 1)
-            for k in range(limit, 0, -1):
-                tail = suffix[-k:]
-                if any(tag.startswith(tail) for tag in self._tags):
-                    best_keep = k
-                    break
-        return len(text) - best_keep, best_keep
+    def _find_next_close(self, text: str, start: int) -> tuple[int, str]:
+        best_idx = -1
+        best_close = ''
+        for _open_tag, close_tag in self._pairs:
+            idx = text.find(close_tag, start)
+            if idx != -1 and (best_idx == -1 or idx < best_idx):
+                best_idx = idx
+                best_close = close_tag
+        return best_idx, best_close
 
-    def _split_for_close_prefix(self, text: str, start: int, close_tag: str) -> tuple[int, int]:
-        suffix = text[start:]
-        best_keep = 0
-        limit = min(len(suffix), len(close_tag) - 1)
-        for k in range(limit, 0, -1):
-            if close_tag.startswith(suffix[-k:]):
-                best_keep = k
-                break
-        return len(text) - best_keep, best_keep
+    def _visible_emit_end(self, text: str, start: int) -> int:
+        visible = text[start:]
+        limit = min(len(visible), max(len(open_tag) for open_tag in self._open_tags) - 1)
+        for keep in range(limit, 0, -1):
+            suffix = visible[-keep:]
+            if any(open_tag.startswith(suffix) for open_tag in self._open_tags):
+                return len(text) - keep
+        return len(text)
+
+    @staticmethod
+    def _close_prefix(text: str, close_tag: str) -> str:
+        limit = min(len(text), len(close_tag) - 1)
+        for keep in range(limit, 0, -1):
+            suffix = text[-keep:]
+            if close_tag.startswith(suffix):
+                return suffix
+        return ''
 
 
 class LiteLLMRequester(requester.ProviderAPIRequester):
@@ -367,11 +382,10 @@ class LiteLLMRequester(requester.ProviderAPIRequester):
 
         return req_messages
 
-    # Patterns covering chain-of-thought markers emitted by various
-    # OpenAI-compatible providers (DeepSeek, MiniMax-M3, etc.) as well
-    # as an internal private marker.
     _THINK_PATTERNS: tuple[str, ...] = (
-        r'</think>',
+        r'^\s*(?:(?!<think>).)*?</think>\s*',
+        r'^\s*(?:(?!CRETIRE_REASONING_BEGINk).)*?CRETIRE_REASONING_ENDk\s*',
+        r'<think>.*?</think>',
         r'CRETIRE_REASONING_BEGINk.*?CRETIRE_REASONING_ENDk',
     )
 
@@ -380,6 +394,7 @@ class LiteLLMRequester(requester.ProviderAPIRequester):
         """Strip chain-of-thought blocks from ``content``."""
         if not content:
             return content
+
         import re
 
         for pattern in cls._THINK_PATTERNS:
@@ -397,16 +412,12 @@ class LiteLLMRequester(requester.ProviderAPIRequester):
         Returns:
             Processed content string
         """
-        # Strip chain-of-thought blocks when requested. The think pattern is
-        # the public convention used by DeepSeek, MiniMax-M3 and other
-        # OpenAI-compatible providers that emit raw reasoning text in the
-        # content field. The CRETIRE_* pattern is an internal marker.
         if remove_think and content:
             content = self._strip_think(content)
 
-        # Handle separate reasoning_content field
-        # Currently we don't include reasoning_content in user-facing output regardless of remove_think
-        # because it's typically internal model reasoning, not user-visible thinking
+        if reasoning_content and not remove_think:
+            content = f'<think>\n{reasoning_content}\n</think>\n{content or ""}'.strip()
+
         return content or ''
 
     @staticmethod
@@ -715,13 +726,7 @@ class LiteLLMRequester(requester.ProviderAPIRequester):
         chunk_idx = 0
         role = 'assistant'
         tool_call_state: dict[int, dict[str, typing.Any]] = {}
-
-        # Stream-level state for `` stripping. `` tags can straddle
-        # chunk boundaries, so use a stateful filter.
-        if remove_think:
-            think_state = _ThinkStripState()
-        else:
-            think_state = None
+        think_state = _ThinkStripState() if remove_think else None
 
         try:
             response = await acompletion(**args)
@@ -765,8 +770,6 @@ class LiteLLMRequester(requester.ProviderAPIRequester):
                         # Use reasoning_content as the displayed content
                         delta_content = reasoning_content
 
-                # Strip `` tags from the delta when remove_think is set.
-                # Think blocks can straddle chunks, so use a stateful filter.
                 if think_state is not None and delta_content:
                     delta_content = think_state.feed(delta_content)
                     if not delta_content:
@@ -793,6 +796,15 @@ class LiteLLMRequester(requester.ProviderAPIRequester):
                 chunk_data = {k: v for k, v in chunk_data.items() if v is not None}
                 yield provider_message.MessageChunk(**chunk_data)
                 chunk_idx += 1
+
+            if think_state is not None:
+                pending_content = think_state.flush()
+                if pending_content:
+                    yield provider_message.MessageChunk(
+                        role=role,
+                        content=pending_content,
+                        is_final=True,
+                    )
 
         except Exception as e:
             self._handle_litellm_error(e)

--- a/src/langbot/pkg/provider/modelmgr/requesters/litellmchat.py
+++ b/src/langbot/pkg/provider/modelmgr/requesters/litellmchat.py
@@ -13,6 +13,135 @@ import langbot_plugin.api.entities.builtin.pipeline.query as pipeline_query
 import langbot_plugin.api.entities.builtin.provider.message as provider_message
 
 
+class _ThinkStripState:
+    """Stateful filter that drops ```` think blocks across chunk boundaries.
+
+    The think tag (and the legacy CRETIRE_* marker) can straddle two or
+    more streaming chunks.  A naive per-chunk regex either fails to match
+    (when split mid-tag) or leaks the tag into user-visible output.  This
+    state machine tracks the longest suffix of the consumed input that is
+    also a prefix of any known tag, and keeps that suffix in an internal
+    buffer for the next call.
+    """
+
+    _OPEN_TAG: str = '</think>'
+    _LEGACY_OPEN: str = 'CRETIRE_REASONING_BEGINk'
+    _LEGACY_CLOSE: str = 'CRETIRE_REASONING_ENDk'
+
+    def __init__(self) -> None:
+        self._tags: tuple[str, ...] = (
+            self._OPEN_TAG,
+            self._CLOSE_TAG,
+            self._LEGACY_OPEN,
+            self._LEGACY_CLOSE,
+        )
+        self._max_tag_len: int = max(len(t) for t in self._tags)
+        self._buf: str = ''
+        self._buf_inside: bool = False
+
+    def feed(self, chunk: str) -> str:
+        """Feed a streaming delta; return the portion that should be emitted."""
+        if not chunk:
+            return chunk
+
+        if self._buf_inside:
+            text = self._buf + chunk
+            for close_tag in (self._CLOSE_TAG, self._LEGACY_CLOSE):
+                idx = text.find(close_tag)
+                if idx != -1:
+                    self._buf = ''
+                    self._buf_inside = False
+                    return self._process(text[idx + len(close_tag) :])
+            keep = 0
+            for tag in (self._CLOSE_TAG, self._LEGACY_CLOSE):
+                _, k = self._split_for_close_prefix(text, 0, tag)
+                if k > keep:
+                    keep = k
+            self._buf = text[len(text) - keep :]
+            return ''
+
+        return self._process(chunk)
+
+    def _process(self, chunk: str) -> str:
+        text = self._buf + chunk
+
+        out: list[str] = []
+        i = 0
+        n = len(text)
+        while i < n:
+            open_idx, open_tag = self._find_open(text, i)
+            if open_idx == -1:
+                emit_end, _keep = self._split_for_tag_prefix(text, i)
+                out.append(text[i:emit_end])
+                self._buf = text[emit_end:]
+                self._buf_inside = False
+                return ''.join(out)
+
+            if open_idx > i:
+                out.append(text[i:open_idx])
+            block_start = open_idx + len(open_tag)
+            close_tag = self._LEGACY_CLOSE if open_tag == self._LEGACY_OPEN else self._CLOSE_TAG
+            close_idx = text.find(close_tag, block_start)
+            if close_idx == -1:
+                emit_end, _keep = self._split_for_close_prefix(text, block_start, close_tag)
+                self._buf = text[emit_end:]
+                self._buf_inside = True
+                return ''.join(out)
+            i = close_idx + len(close_tag)
+
+        emit_end, _keep = self._split_for_tag_prefix(text, i)
+        out.append(text[i:emit_end])
+        self._buf = text[emit_end:]
+        self._buf_inside = False
+        return ''.join(out)
+
+    def flush(self) -> str:
+        """Release any text still held in the internal buffer."""
+        pending, self._buf = self._buf, ''
+        inside, self._buf_inside = self._buf_inside, False
+        if inside:
+            return ''
+        return pending
+
+    def _find_open(self, text: str, start: int) -> tuple[int, str]:
+        best_idx = -1
+        best_tag = ''
+        for tag in (self._OPEN_TAG, self._LEGACY_OPEN):
+            idx = text.find(tag, start)
+            if idx != -1 and (best_idx == -1 or idx < best_idx):
+                best_idx = idx
+                best_tag = tag
+        return best_idx, best_tag
+
+    def _split_for_tag_prefix(self, text: str, start: int) -> tuple[int, int]:
+        suffix = text[start:]
+        best_keep = 0
+        for tag in (self._OPEN_TAG, self._LEGACY_OPEN):
+            idx = suffix.find(tag)
+            if idx != -1:
+                candidate = len(suffix) - idx
+                if candidate > best_keep:
+                    best_keep = candidate
+        if best_keep == 0:
+            limit = min(len(suffix), self._max_tag_len - 1)
+            for k in range(limit, 0, -1):
+                tail = suffix[-k:]
+                if any(tag.startswith(tail) for tag in self._tags):
+                    best_keep = k
+                    break
+        return len(text) - best_keep, best_keep
+
+    def _split_for_close_prefix(self, text: str, start: int, close_tag: str) -> tuple[int, int]:
+        suffix = text[start:]
+        best_keep = 0
+        limit = min(len(suffix), len(close_tag) - 1)
+        for k in range(limit, 0, -1):
+            if close_tag.startswith(suffix[-k:]):
+                best_keep = k
+                break
+        return len(text) - best_keep, best_keep
+
+
 class LiteLLMRequester(requester.ProviderAPIRequester):
     """LiteLLM unified API requester supporting chat, embedding, and rerank."""
 
@@ -237,6 +366,25 @@ class LiteLLMRequester(requester.ProviderAPIRequester):
 
         return req_messages
 
+    # Patterns covering chain-of-thought markers emitted by various
+    # OpenAI-compatible providers (DeepSeek, MiniMax-M3, etc.) as well
+    # as an internal private marker.
+    _THINK_PATTERNS: tuple[str, ...] = (
+        r'</think>',
+        r'CRETIRE_REASONING_BEGINk.*?CRETIRE_REASONING_ENDk',
+    )
+
+    @classmethod
+    def _strip_think(cls, content: str) -> str:
+        """Strip chain-of-thought blocks from ``content``."""
+        if not content:
+            return content
+        import re
+
+        for pattern in cls._THINK_PATTERNS:
+            content = re.sub(pattern, '', content, flags=re.DOTALL)
+        return content.strip()
+
     def _process_thinking_content(self, content: str, reasoning_content: str | None, remove_think: bool) -> str:
         """Process thinking/reasoning content.
 
@@ -248,16 +396,12 @@ class LiteLLMRequester(requester.ProviderAPIRequester):
         Returns:
             Processed content string
         """
-        # Extract and handle thinking tags
-        if content and 'CRETIRE_REASONING_BEGINk' in content and 'CRETIRE_REASONING_ENDk' in content:
-            import re
-
-            think_pattern = r'CRETIRE_REASONING_BEGINk(.*?)CRETIRE_REASONING_ENDk'
-
-            if remove_think:
-                # Remove thinking tags and their content from output
-                content = re.sub(think_pattern, '', content, flags=re.DOTALL).strip()
-            # else: preserve thinking content as-is
+        # Strip chain-of-thought blocks when requested. The think pattern is
+        # the public convention used by DeepSeek, MiniMax-M3 and other
+        # OpenAI-compatible providers that emit raw reasoning text in the
+        # content field. The CRETIRE_* pattern is an internal marker.
+        if remove_think and content:
+            content = self._strip_think(content)
 
         # Handle separate reasoning_content field
         # Currently we don't include reasoning_content in user-facing output regardless of remove_think
@@ -571,6 +715,13 @@ class LiteLLMRequester(requester.ProviderAPIRequester):
         role = 'assistant'
         tool_call_state: dict[int, dict[str, typing.Any]] = {}
 
+        # Stream-level state for `` stripping. `` tags can straddle
+        # chunk boundaries, so use a stateful filter.
+        if remove_think:
+            think_state = _ThinkStripState()
+        else:
+            think_state = None
+
         try:
             response = await acompletion(**args)
             async for chunk in response:
@@ -612,6 +763,14 @@ class LiteLLMRequester(requester.ProviderAPIRequester):
                     else:
                         # Use reasoning_content as the displayed content
                         delta_content = reasoning_content
+
+                # Strip `` tags from the delta when remove_think is set.
+                # Think blocks can straddle chunks, so use a stateful filter.
+                if think_state is not None and delta_content:
+                    delta_content = think_state.feed(delta_content)
+                    if not delta_content:
+                        chunk_idx += 1
+                        continue
 
                 tool_calls = self._normalize_stream_tool_calls(delta.get('tool_calls'), tool_call_state)
 

--- a/src/langbot/pkg/provider/runners/localagent.py
+++ b/src/langbot/pkg/provider/runners/localagent.py
@@ -47,14 +47,28 @@ def _model_has_ability(model: modelmgr_requester.RuntimeLLMModel, ability: str) 
 
 
 class _StreamAccumulator:
-    """Accumulate streamed content and fragmented OpenAI-style tool calls."""
+    """Accumulate streamed content and fragmented OpenAI-style tool calls.
 
-    def __init__(self, msg_sequence: int = 0, initial_content: str | None = None):
+    When ``remove_think`` is enabled, the accumulator performs a final pass
+    over the accumulated content to strip chain-of-thought blocks as a
+    safety net. The upstream LLM requester is expected to have already
+    stripped its own streaming chunks, but the local agent runner can
+    re-invoke the LLM after tool calls and that second pass may produce
+    content that has not been filtered yet.
+    """
+
+    def __init__(
+        self,
+        msg_sequence: int = 0,
+        initial_content: str | None = None,
+        remove_think: bool = False,
+    ):
         self.tool_calls_map: dict[str, provider_message.ToolCall] = {}
         self.msg_idx = 0
         self.accumulated_content = initial_content or ''
         self.last_role = 'assistant'
         self.msg_sequence = msg_sequence
+        self.remove_think = remove_think
 
     def add(self, msg: provider_message.MessageChunk) -> provider_message.MessageChunk | None:
         self.msg_idx += 1
@@ -83,7 +97,7 @@ class _StreamAccumulator:
             self.msg_sequence += 1
             return provider_message.MessageChunk(
                 role=self.last_role,
-                content=self.accumulated_content,
+                content=self._maybe_strip(self.accumulated_content),
                 tool_calls=list(self.tool_calls_map.values()) if (self.tool_calls_map and msg.is_final) else None,
                 is_final=msg.is_final,
                 msg_sequence=self.msg_sequence,
@@ -94,10 +108,17 @@ class _StreamAccumulator:
     def final_message(self) -> provider_message.MessageChunk:
         return provider_message.MessageChunk(
             role=self.last_role,
-            content=self.accumulated_content,
+            content=self._maybe_strip(self.accumulated_content),
             tool_calls=list(self.tool_calls_map.values()) if self.tool_calls_map else None,
             msg_sequence=self.msg_sequence,
         )
+
+    def _maybe_strip(self, content: str) -> str:
+        if not self.remove_think or not content:
+            return content
+        from ..modelmgr.requesters.litellmchat import LiteLLMRequester
+
+        return LiteLLMRequester._strip_think(content)
 
 
 @runner.runner_class('local-agent')
@@ -448,7 +469,9 @@ class LocalAgentRunner(runner.RequestRunner):
         except AttributeError:
             is_stream = False
 
-        remove_think = query.pipeline_config['output'].get('misc', '').get('remove-think')
+        # Safely resolve the "remove think blocks" toggle. ``output.misc``
+        # is not guaranteed to exist on every pipeline configuration.
+        remove_think = ((query.pipeline_config.get('output') or {}).get('misc') or {}).get('remove-think', False)
 
         # Build ordered candidate list (primary + fallbacks)
         candidates = await self._get_model_candidates(query)
@@ -472,7 +495,7 @@ class LocalAgentRunner(runner.RequestRunner):
             final_msg = msg
         else:
             # Streaming: invoke with fallback
-            stream_accumulator = _StreamAccumulator(msg_sequence=1)
+            stream_accumulator = _StreamAccumulator(msg_sequence=1, remove_think=remove_think)
 
             stream_src, use_llm_model = await self._invoke_stream_with_fallback(
                 query,
@@ -576,6 +599,7 @@ class LocalAgentRunner(runner.RequestRunner):
                 stream_accumulator = _StreamAccumulator(
                     msg_sequence=first_end_sequence,
                     initial_content=first_content,
+                    remove_think=remove_think,
                 )
 
                 tool_stream_src = use_llm_model.provider.invoke_llm_stream(

--- a/src/langbot/pkg/provider/runners/localagent.py
+++ b/src/langbot/pkg/provider/runners/localagent.py
@@ -47,15 +47,7 @@ def _model_has_ability(model: modelmgr_requester.RuntimeLLMModel, ability: str) 
 
 
 class _StreamAccumulator:
-    """Accumulate streamed content and fragmented OpenAI-style tool calls.
-
-    When ``remove_think`` is enabled, the accumulator performs a final pass
-    over the accumulated content to strip chain-of-thought blocks as a
-    safety net. The upstream LLM requester is expected to have already
-    stripped its own streaming chunks, but the local agent runner can
-    re-invoke the LLM after tool calls and that second pass may produce
-    content that has not been filtered yet.
-    """
+    """Accumulate streamed content and fragmented OpenAI-style tool calls."""
 
     def __init__(
         self,
@@ -69,6 +61,11 @@ class _StreamAccumulator:
         self.last_role = 'assistant'
         self.msg_sequence = msg_sequence
         self.remove_think = remove_think
+        self._think_state = None
+        if remove_think:
+            from ..modelmgr.requesters.litellmchat import _ThinkStripState
+
+            self._think_state = _ThinkStripState()
 
     def add(self, msg: provider_message.MessageChunk) -> provider_message.MessageChunk | None:
         self.msg_idx += 1
@@ -77,7 +74,10 @@ class _StreamAccumulator:
             self.last_role = msg.role
 
         if msg.content:
-            self.accumulated_content += msg.content
+            content = msg.content
+            if self._think_state is not None:
+                content = self._think_state.feed(content)
+            self.accumulated_content += content
 
         if msg.tool_calls:
             for tool_call in msg.tool_calls:
@@ -93,11 +93,14 @@ class _StreamAccumulator:
                 if tool_call.function and tool_call.function.arguments:
                     self.tool_calls_map[tool_call.id].function.arguments += tool_call.function.arguments
 
+        if msg.is_final:
+            self._flush_think_state()
+
         if self.msg_idx % 8 == 0 or msg.is_final:
             self.msg_sequence += 1
             return provider_message.MessageChunk(
                 role=self.last_role,
-                content=self._maybe_strip(self.accumulated_content),
+                content=self._maybe_strip_think(self.accumulated_content),
                 tool_calls=list(self.tool_calls_map.values()) if (self.tool_calls_map and msg.is_final) else None,
                 is_final=msg.is_final,
                 msg_sequence=self.msg_sequence,
@@ -106,19 +109,28 @@ class _StreamAccumulator:
         return None
 
     def final_message(self) -> provider_message.MessageChunk:
+        self._flush_think_state()
         return provider_message.MessageChunk(
             role=self.last_role,
-            content=self._maybe_strip(self.accumulated_content),
+            content=self._maybe_strip_think(self.accumulated_content),
             tool_calls=list(self.tool_calls_map.values()) if self.tool_calls_map else None,
             msg_sequence=self.msg_sequence,
         )
 
-    def _maybe_strip(self, content: str) -> str:
+    def _maybe_strip_think(self, content: str) -> str:
         if not self.remove_think or not content:
             return content
+
         from ..modelmgr.requesters.litellmchat import LiteLLMRequester
 
         return LiteLLMRequester._strip_think(content)
+
+    def _flush_think_state(self) -> None:
+        if self._think_state is None:
+            return
+        pending = self._think_state.flush()
+        if pending:
+            self.accumulated_content += pending
 
 
 @runner.runner_class('local-agent')
@@ -469,8 +481,6 @@ class LocalAgentRunner(runner.RequestRunner):
         except AttributeError:
             is_stream = False
 
-        # Safely resolve the "remove think blocks" toggle. ``output.misc``
-        # is not guaranteed to exist on every pipeline configuration.
         remove_think = ((query.pipeline_config.get('output') or {}).get('misc') or {}).get('remove-think', False)
 
         # Build ordered candidate list (primary + fallbacks)

--- a/tests/unit_tests/provider/test_litellmchat.py
+++ b/tests/unit_tests/provider/test_litellmchat.py
@@ -280,6 +280,122 @@ class TestInvokeLLMStreamUsage:
         assert query.variables['_stream_usage']['total_tokens'] == 12
 
     @pytest.mark.asyncio
+    async def test_stream_removes_leading_think_across_chunks(self):
+        """A leading think block split across chunks must be removed."""
+        import langbot_plugin.api.entities.builtin.pipeline.query as pipeline_query
+        import langbot_plugin.api.entities.builtin.provider.message as provider_message
+
+        mock_ap = Mock()
+        mock_ap.tool_mgr = Mock()
+        mock_ap.tool_mgr.generate_tools_for_openai = AsyncMock(return_value=None)
+        requester = litellmchat.LiteLLMRequester(ap=mock_ap, config={})
+        model = MockRuntimeModel('minimax-m3', 'test-api-key')
+
+        chunks = [
+            self._make_chunk(content='<thi'),
+            self._make_chunk(content='nk>hidden'),
+            self._make_chunk(content=' reasoning</thi'),
+            self._make_chunk(content='nk>Visible answer', finish_reason='stop'),
+        ]
+
+        async def _aiter(*args, **kwargs):
+            for c in chunks:
+                yield c
+
+        query = Mock(spec=pipeline_query.Query)
+        query.variables = {}
+        messages = [provider_message.Message(role='user', content='Hi')]
+
+        with patch.object(litellmchat, 'acompletion', new=AsyncMock(side_effect=lambda **kw: _aiter())):
+            collected = [
+                chunk
+                async for chunk in requester.invoke_llm_stream(
+                    query=query,
+                    model=model,
+                    messages=messages,
+                    remove_think=True,
+                )
+            ]
+
+        assert ''.join(chunk.content or '' for chunk in collected) == 'Visible answer'
+
+    @pytest.mark.asyncio
+    async def test_stream_removes_initial_orphan_think_close(self):
+        """Initial reasoning content without an open tag is removed until </think>."""
+        import langbot_plugin.api.entities.builtin.pipeline.query as pipeline_query
+        import langbot_plugin.api.entities.builtin.provider.message as provider_message
+
+        mock_ap = Mock()
+        mock_ap.tool_mgr = Mock()
+        mock_ap.tool_mgr.generate_tools_for_openai = AsyncMock(return_value=None)
+        requester = litellmchat.LiteLLMRequester(ap=mock_ap, config={})
+        model = MockRuntimeModel('minimax-m3', 'test-api-key')
+
+        chunks = [
+            self._make_chunk(content='hidden reasoning'),
+            self._make_chunk(content=' still hidden</thi'),
+            self._make_chunk(content='nk>Visible answer', finish_reason='stop'),
+        ]
+
+        async def _aiter(*args, **kwargs):
+            for c in chunks:
+                yield c
+
+        query = Mock(spec=pipeline_query.Query)
+        query.variables = {}
+        messages = [provider_message.Message(role='user', content='Hi')]
+
+        with patch.object(litellmchat, 'acompletion', new=AsyncMock(side_effect=lambda **kw: _aiter())):
+            collected = [
+                chunk
+                async for chunk in requester.invoke_llm_stream(
+                    query=query,
+                    model=model,
+                    messages=messages,
+                    remove_think=True,
+                )
+            ]
+
+        assert ''.join(chunk.content or '' for chunk in collected) == 'Visible answer'
+
+    @pytest.mark.asyncio
+    async def test_stream_removes_non_leading_think_content(self):
+        """A think block in the answer body is removed with its content."""
+        import langbot_plugin.api.entities.builtin.pipeline.query as pipeline_query
+        import langbot_plugin.api.entities.builtin.provider.message as provider_message
+
+        mock_ap = Mock()
+        mock_ap.tool_mgr = Mock()
+        mock_ap.tool_mgr.generate_tools_for_openai = AsyncMock(return_value=None)
+        requester = litellmchat.LiteLLMRequester(ap=mock_ap, config={})
+        model = MockRuntimeModel('gpt-4o', 'test-api-key')
+
+        chunks = [
+            self._make_chunk(content='Use <think>x</think> as an XML-like example.', finish_reason='stop'),
+        ]
+
+        async def _aiter(*args, **kwargs):
+            for c in chunks:
+                yield c
+
+        query = Mock(spec=pipeline_query.Query)
+        query.variables = {}
+        messages = [provider_message.Message(role='user', content='Hi')]
+
+        with patch.object(litellmchat, 'acompletion', new=AsyncMock(side_effect=lambda **kw: _aiter())):
+            collected = [
+                chunk
+                async for chunk in requester.invoke_llm_stream(
+                    query=query,
+                    model=model,
+                    messages=messages,
+                    remove_think=True,
+                )
+            ]
+
+        assert ''.join(chunk.content or '' for chunk in collected) == 'Use  as an XML-like example.'
+
+    @pytest.mark.asyncio
     async def test_stream_tool_call_delta_missing_id_and_name(self):
         """LiteLLM may stream tool-call argument deltas with id/name set to None."""
         import langbot_plugin.api.entities.builtin.pipeline.query as pipeline_query
@@ -482,6 +598,38 @@ class TestProcessThinkingContent:
         result = requester._process_thinking_content(content, None, remove_think=True)
         assert result == 'The answer is 42.'
 
+    def test_remove_leading_think_tag(self):
+        """Test removing a leading <think> block when remove_think=True"""
+        requester = litellmchat.LiteLLMRequester(ap=Mock(), config={})
+
+        content = '<think>Let me think...</think> The answer is 42.'
+        result = requester._process_thinking_content(content, None, remove_think=True)
+        assert result == 'The answer is 42.'
+
+    def test_remove_non_leading_think_tag(self):
+        """Test removing <think> and its content in the answer body"""
+        requester = litellmchat.LiteLLMRequester(ap=Mock(), config={})
+
+        content = 'Use <think>example</think> in the document.'
+        result = requester._process_thinking_content(content, None, remove_think=True)
+        assert result == 'Use  in the document.'
+
+    def test_remove_initial_orphan_think_close(self):
+        """Test removing leading reasoning content when only </think> is visible"""
+        requester = litellmchat.LiteLLMRequester(ap=Mock(), config={})
+
+        content = 'hidden reasoning</think> Visible answer.'
+        result = requester._process_thinking_content(content, None, remove_think=True)
+        assert result == 'Visible answer.'
+
+    def test_remove_multiple_think_tags(self):
+        """Test removing multiple <think> blocks"""
+        requester = litellmchat.LiteLLMRequester(ap=Mock(), config={})
+
+        content = '<think>hidden</think> Keep <think>example</think>.'
+        result = requester._process_thinking_content(content, None, remove_think=True)
+        assert result == 'Keep .'
+
     def test_preserve_thinking_markers(self):
         """Test preserving thinking markers when remove_think=False"""
         requester = litellmchat.LiteLLMRequester(ap=Mock(), config={})
@@ -490,6 +638,20 @@ class TestProcessThinkingContent:
         result = requester._process_thinking_content(content, None, remove_think=False)
         assert 'CRETIRE_REASONING_BEGINk' in result
         assert 'The answer is 42.' in result
+
+    def test_preserve_reasoning_content_when_remove_think_false(self):
+        """Test showing separate reasoning_content when remove_think=False"""
+        requester = litellmchat.LiteLLMRequester(ap=Mock(), config={})
+
+        result = requester._process_thinking_content('The answer is 42.', 'Let me think...', remove_think=False)
+        assert result == '<think>\nLet me think...\n</think>\nThe answer is 42.'
+
+    def test_hide_reasoning_content_when_remove_think_true(self):
+        """Test hiding separate reasoning_content when remove_think=True"""
+        requester = litellmchat.LiteLLMRequester(ap=Mock(), config={})
+
+        result = requester._process_thinking_content('The answer is 42.', 'Let me think...', remove_think=True)
+        assert result == 'The answer is 42.'
 
     def test_empty_content(self):
         """Test empty content"""

--- a/tests/unit_tests/provider/test_localagent_sandbox_exec.py
+++ b/tests/unit_tests/provider/test_localagent_sandbox_exec.py
@@ -163,6 +163,51 @@ def test_stream_accumulator_merges_fragmented_tool_call_arguments():
     assert final_msg.tool_calls[0].function.arguments == '{"command":"pwd"}'
 
 
+def test_stream_accumulator_strips_leading_think_from_tool_round_content():
+    accumulator = _StreamAccumulator(
+        msg_sequence=3,
+        initial_content='I will search for LangBot.',
+        remove_think=True,
+    )
+
+    assert accumulator.add(provider_message.MessageChunk(role='assistant', content='<thi')) is None
+    assert accumulator.add(provider_message.MessageChunk(role='assistant', content='nk>hidden')) is None
+    emitted = accumulator.add(
+        provider_message.MessageChunk(
+            role='assistant',
+            content=' reasoning</think>Here is the answer.',
+            is_final=True,
+        )
+    )
+
+    assert emitted is not None
+    assert emitted.content == 'I will search for LangBot.Here is the answer.'
+    assert '<think>' not in emitted.content
+    assert 'hidden reasoning' not in emitted.content
+
+
+def test_stream_accumulator_strips_initial_orphan_think_close_from_tool_round_content():
+    accumulator = _StreamAccumulator(
+        msg_sequence=3,
+        initial_content='I will search for LangBot.',
+        remove_think=True,
+    )
+
+    assert accumulator.add(provider_message.MessageChunk(role='assistant', content='hidden reasoning')) is None
+    emitted = accumulator.add(
+        provider_message.MessageChunk(
+            role='assistant',
+            content=' still hidden</think>Here is the answer.',
+            is_final=True,
+        )
+    )
+
+    assert emitted is not None
+    assert emitted.content == 'I will search for LangBot.Here is the answer.'
+    assert '</think>' not in emitted.content
+    assert 'hidden reasoning' not in emitted.content
+
+
 @pytest.mark.asyncio
 async def test_localagent_uses_exec_for_exact_calculation():
     provider = RecordingProvider()


### PR DESCRIPTION
## 概述 / Overview

> 修复开启「删除思维链」(remove-think) 后，MiniMax-M3 等模型的思维链仍泄露到用户可见输出的问题。
>
> **根因**：MiniMax-M3 等 OpenAI 兼容模型将思维链直接放在 `content` 字段中，用 `` 标签包裹，而非使用独立的 `reasoning_content` 字段或旧版 `CRETIRE_REASONING` 标记。现有 `remove_think` 逻辑只处理 `CRETIRE_*` 标记，完全忽略了 `` 标签。
>
> 修复内容：
>
> 1. **新增 `_ThinkStripState` 状态机**：`` 标签可能跨越多个流式 chunk 边界（开标签在 chunk N，内容在 N+1，闭标签在 N+2），逐 chunk 正则无法正确匹配。该状态机跟踪已消费输入的最长后缀是否为已知标签的前缀，将不确定的文本暂存到下一次调用。
>
> 2. **新增 `_strip_think` 方法和 `_THINK_PATTERNS`**：正则匹配 `` 和 `CRETIRE_REASONING_BEGINk...ENDk` 两种模式，用于非流式路径的最终内容剥离。
>
> 3. **流式路径集成 `think_state`**：在 `invoke_llm_stream` 中，当 `remove_think=True` 时，每个 delta content 先经过 `think_state.feed()` 过滤再传给 accumulator。
>
> 4. **`_StreamAccumulator` 安全网**：添加 `remove_think` 参数，在 `add()` 和 `final_message()` 中对累积内容做最终 `_strip_think` 处理，防止工具调用后续轮次的内容未被过滤。
>
> 5. **防御性配置解析**：`remove_think` 的读取改为 `(config.get('output') or {}).get('misc') or {}).get('remove-think', False)`，避免缺少 `output.misc` 的 pipeline 配置触发 `AttributeError`。

### 更改前后对比截图 / Screenshots

> 修改前 / Before:
> - 开启「删除思维链」后，MiniMax-M3 返回的消息中仍包含 `思维链内容...实际回复`，思维链直接展示给用户
>
<img width="838" height="524" alt="image" src="https://github.com/user-attachments/assets/1ea52451-a771-4c19-85b4-68a5de19aebb" />


> 修改后 / After:
> - 思维链标签及其内容被正确剥离，用户只看到 `实际回复`
<img width="835" height="643" alt="image" src="https://github.com/user-attachments/assets/396612d7-78c5-4e4c-bf8a-28712d1ffb87" />

## 检查清单 / Checklist

### PR 作者完成 / For PR author

*请在方括号间写`x`以打勾 / Please tick the box with `x`*

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [x] 我已签署或将在机器人提示后签署 [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。 / I have signed, or will sign when prompted by the bot, the [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md).
- [x] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] 文档编写了吗？ / Have you written the documentation?
