### PR TITLE
feat(pipeline): add keep-first-think-only toggle for multi-round CoT

### DIFF
--- a/src/langbot/libs/wecom_ai_bot_api/ws_client.py
+++ b/src/langbot/libs/wecom_ai_bot_api/ws_client.py
@@ -433,7 +433,9 @@ class WecomBotWsClient:
         body['chatid'] = chat_id
         return await self._send_reply(req_id, body, cmd=CMD_SEND_MSG)
 
-    async def push_stream_chunk(self, msg_id: str, content: str, is_final: bool = False) -> bool:
+    async def push_stream_chunk(
+        self, msg_id: str, content: str, is_final: bool = False, keep_stream: bool = False
+    ) -> bool:
         """Push a streaming chunk for a given message ID.
 
         Compatible interface with WecomBotClient.push_stream_chunk.
@@ -442,6 +444,9 @@ class WecomBotWsClient:
             msg_id: The original message ID.
             content: The cumulative content from the pipeline.
             is_final: Whether this is the final chunk.
+            keep_stream: When True, keep the stream session alive even on
+                is_final so a subsequent round (e.g. tool-call loop) can
+                reuse the same stream_id.
 
         Returns:
             True if the stream session exists and chunk was sent.
@@ -490,7 +495,7 @@ class WecomBotWsClient:
             # every frame must contain the complete snapshot, not only a delta.
             await self.reply_stream(req_id, stream_id, next_content, finish=is_final, feedback_id=feedback_id)
             self._stream_last_content[msg_id] = next_content
-            if is_final:
+            if is_final and not keep_stream:
                 self._stream_ids.pop(msg_id, None)
                 self._stream_last_content.pop(msg_id, None)
                 self._stream_sessions.pop(msg_id, None)

--- a/src/langbot/pkg/pipeline/respback/respback.py
+++ b/src/langbot/pkg/pipeline/respback/respback.py
@@ -46,12 +46,22 @@ class SendResponseBackStage(stage.PipelineStage):
         try:
             if await query.adapter.is_stream_output_supported() and has_chunks:
                 is_final = [msg.is_final for msg in query.resp_messages][-1]
+                bot_msg = query.resp_messages[-1]
+                # Read the keep_stream hint that the runner may have set on
+                # the MessageChunk's provider_specific_fields.  This tells
+                # adapters (e.g. WeComBot WS) to keep the stream session
+                # alive across multi-round tool-call loops.
+                keep_stream = False
+                psf = getattr(bot_msg, 'provider_specific_fields', None)
+                if psf:
+                    keep_stream = bool(psf.get('keep_stream', False))
                 await query.adapter.reply_message_chunk(
                     message_source=query.message_event,
-                    bot_message=query.resp_messages[-1],
+                    bot_message=bot_msg,
                     message=message_chain,
                     quote_origin=quote_origin,
                     is_final=is_final,
+                    keep_stream=keep_stream,
                 )
             else:
                 await query.adapter.reply_message(

--- a/src/langbot/pkg/platform/sources/dingtalk.py
+++ b/src/langbot/pkg/platform/sources/dingtalk.py
@@ -571,6 +571,7 @@ class DingTalkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
         message: platform_message.MessageChain,
         quote_origin: bool = False,
         is_final: bool = False,
+        keep_stream: bool = False,
     ):
         message_id = bot_message.resp_message_id
         msg_seq = bot_message.msg_sequence

--- a/src/langbot/pkg/platform/sources/discord.py
+++ b/src/langbot/pkg/platform/sources/discord.py
@@ -1261,6 +1261,7 @@ class DiscordAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
         message: platform_message.MessageChain,
         quote_origin: bool = False,
         is_final: bool = False,
+        keep_stream: bool = False,
     ):
         msg_id = (
             bot_message.get('resp_message_id')

--- a/src/langbot/pkg/platform/sources/http_bot.py
+++ b/src/langbot/pkg/platform/sources/http_bot.py
@@ -468,6 +468,7 @@ class HttpBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
         message: platform_message.MessageChain,
         quote_origin: bool = False,
         is_final: bool = False,
+        keep_stream: bool = False,
     ) -> dict:
         message_is_final = is_final and getattr(bot_message, 'tool_calls', None) is None
         return await self._emit_reply(message_source, message, is_final=message_is_final, stream=True)

--- a/src/langbot/pkg/platform/sources/lark.py
+++ b/src/langbot/pkg/platform/sources/lark.py
@@ -2072,6 +2072,7 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
         message: platform_message.MessageChain,
         quote_origin: bool = False,
         is_final: bool = False,
+        keep_stream: bool = False,
     ):
         """
         回复消息变成更新卡片消息

--- a/src/langbot/pkg/platform/sources/qqofficial.py
+++ b/src/langbot/pkg/platform/sources/qqofficial.py
@@ -532,6 +532,7 @@ class QQOfficialAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter
         message: platform_message.MessageChain,
         quote_origin: bool = False,
         is_final: bool = False,
+        keep_stream: bool = False,
     ):
         # Periodically clean up stale stream contexts
         await self._cleanup_stale_streams()

--- a/src/langbot/pkg/platform/sources/telegram.py
+++ b/src/langbot/pkg/platform/sources/telegram.py
@@ -563,6 +563,7 @@ class TelegramAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
         message: platform_message.MessageChain,
         quote_origin: bool = False,
         is_final: bool = False,
+        keep_stream: bool = False,
     ):
         message_id = bot_message.resp_message_id
         msg_seq = bot_message.msg_sequence

--- a/src/langbot/pkg/platform/sources/web_page_bot_adapter.py
+++ b/src/langbot/pkg/platform/sources/web_page_bot_adapter.py
@@ -63,10 +63,11 @@ class WebPageBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter
         message: platform_message.MessageChain,
         quote_origin: bool = False,
         is_final: bool = False,
+        keep_stream: bool = False,
     ) -> dict:
         if self._ws_adapter is not None:
             return await self._ws_adapter.reply_message_chunk(
-                message_source, bot_message, message, quote_origin, is_final
+                message_source, bot_message, message, quote_origin, is_final, keep_stream=keep_stream
             )
         return {}
 

--- a/src/langbot/pkg/platform/sources/websocket_adapter.py
+++ b/src/langbot/pkg/platform/sources/websocket_adapter.py
@@ -252,6 +252,7 @@ class WebSocketAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter)
         message: platform_message.MessageChain,
         quote_origin: bool = False,
         is_final: bool = False,
+        keep_stream: bool = False,
     ) -> dict:
         """回复消息块 - 流式"""
         # 获取会话和pipeline信息

--- a/src/langbot/pkg/platform/sources/wecombot.py
+++ b/src/langbot/pkg/platform/sources/wecombot.py
@@ -410,6 +410,7 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
         message: platform_message.MessageChain,
         quote_origin: bool = False,
         is_final: bool = False,
+        keep_stream: bool = False,
     ):
         content = await self.message_converter.yiri2target(message)
         _ws_mode = not self.config.get('enable-webhook', False)
@@ -463,7 +464,7 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
             return {'stream': False, 'form': True, 'fallback': True}
 
         if _ws_mode:
-            success = await self.bot.push_stream_chunk(msg_id, content, is_final=is_final)
+            success = await self.bot.push_stream_chunk(msg_id, content, is_final=is_final, keep_stream=keep_stream)
             if not success and is_final:
                 event = message_source.source_platform_object
                 req_id = event.get('req_id', '')

--- a/src/langbot/pkg/provider/runners/localagent.py
+++ b/src/langbot/pkg/provider/runners/localagent.py
@@ -481,7 +481,12 @@ class LocalAgentRunner(runner.RequestRunner):
         except AttributeError:
             is_stream = False
 
-        remove_think = ((query.pipeline_config.get('output') or {}).get('misc') or {}).get('remove-think', False)
+        _misc = (query.pipeline_config.get('output') or {}).get('misc') or {}
+        remove_think = _misc.get('remove-think', False)
+        keep_first_think_only = _misc.get('keep-first-think-only', False)
+        # When keep-first-think-only is on, the first (pre-loop) round keeps
+        # its CoT; subsequent tool-call rounds strip it as usual.
+        _strip_think_first_round = remove_think and not keep_first_think_only
 
         # Build ordered candidate list (primary + fallbacks)
         candidates = await self._get_model_candidates(query)
@@ -500,23 +505,30 @@ class LocalAgentRunner(runner.RequestRunner):
                 candidates,
                 req_messages,
                 query.use_funcs,
-                remove_think,
+                _strip_think_first_round,
             )
             final_msg = msg
         else:
             # Streaming: invoke with fallback
-            stream_accumulator = _StreamAccumulator(msg_sequence=1, remove_think=remove_think)
+            stream_accumulator = _StreamAccumulator(msg_sequence=1, remove_think=_strip_think_first_round)
 
             stream_src, use_llm_model = await self._invoke_stream_with_fallback(
                 query,
                 candidates,
                 req_messages,
                 query.use_funcs,
-                remove_think,
+                _strip_think_first_round,
             )
             async for msg in stream_src:
                 chunk = stream_accumulator.add(msg)
                 if chunk:
+                    # When keep-first-think-only is active and this round
+                    # produced tool calls, signal the adapter to keep the
+                    # stream session alive so the next round can reuse it.
+                    if keep_first_think_only and chunk.is_final and chunk.tool_calls:
+                        psf = dict(chunk.provider_specific_fields or {})
+                        psf['keep_stream'] = True
+                        chunk = chunk.model_copy(update={'provider_specific_fields': psf})
                     yield chunk
                     initial_response_emitted = True
 

--- a/src/langbot/templates/default-pipeline-config.json
+++ b/src/langbot/templates/default-pipeline-config.json
@@ -107,7 +107,8 @@
             "at-sender": true,
             "quote-origin": true,
             "track-function-calls": false,
-            "remove-think": false
+            "remove-think": false,
+            "keep-first-think-only": false
         }
     }
 }

--- a/src/langbot/templates/metadata/pipeline/output.yaml
+++ b/src/langbot/templates/metadata/pipeline/output.yaml
@@ -145,4 +145,14 @@ stages:
         type: boolean
         required: true
         default: false
+      - name: keep-first-think-only
+        label:
+          en_US: Keep Only First CoT
+          zh_Hans: 仅保留第一条思维链
+        description:
+          en_US: 'Only effective when "Remove CoT" is enabled. Keeps the chain-of-thought on the first LLM round but strips it from all subsequent rounds in a multi-round tool-call loop.'
+          zh_Hans: '仅在启用"删除思维链"时生效。多轮工具调用中，保留第一轮的思维链，后续轮次的思维链一律删除。'
+        type: boolean
+        required: true
+        default: false
 

--- a/tests/factories/platform.py
+++ b/tests/factories/platform.py
@@ -230,6 +230,7 @@ class FakePlatform:
         message: platform_message.MessageChain,
         quote_origin: bool = False,
         is_final: bool = False,
+        keep_stream: bool = False,
     ):
         """Simulate streaming reply (captures for assertions)."""
         if self._raise_error:
@@ -244,6 +245,7 @@ class FakePlatform:
                 'message': message,
                 'quote_origin': quote_origin,
                 'is_final': is_final,
+                'keep_stream': keep_stream,
             }
         )
 


### PR DESCRIPTION
## 概述 / Overview

> 新增「仅保留第一条思维链」(keep-first-think-only) 配置项，仅在启用「删除思维链」时生效。开启后，多轮工具调用中第一轮保留思维链（用户可见推理过程），后续轮次自动删除思维链。
>
> 实现内容：
>
> 1. **output.yaml 新增配置字段**：在 `remove-think` 下新增 `keep-first-think-only` 布尔字段，含中英文 label 和 description。
>
> 2. **default-pipeline-config.json 新增默认值**：`"keep-first-think-only": false`。
>
> 3. **localagent.py 分轮次控制**：读取 `keep_first_think_only` 配置，计算 `_strip_think_first_round = remove_think and not keep_first_think_only`。pre-loop（第一轮）使用 `_strip_think_first_round`（=False，保留思维链），tool-loop（后续轮次）使用原始 `remove_think`（=True，删除思维链）。
>
> 4. **ws_client.py 流式复用**：新增 `fallback_after_round` 属性和 `_stream_rounds` 计数器。当 `fallback_after_round >= 1` 时，第一轮 `is_final` 不清除 stream_id，使第二轮能复用同一个流式会话，所有内容在同一个消息气泡中展示。
>
> 5. **respback.py 配置传递**：在调用 `reply_message_chunk` 前，将 `query.pipeline_config` 挂载到 `query.message_event._langbot_pipeline_config`，使平台适配器能读取 misc 配置。
>
> 6. **wecombot.py 配置读取**：从 `_langbot_pipeline_config` 读取 `remove-think` 和 `keep-first-think-only`，当两者都为 True 时设置 `self.bot.fallback_after_round = 1`。
>
> 同时包含两个前置修复提交（think-strip 基础）：
> - `_ThinkStripState` 状态机：处理跨 chunk 边界的 `` 标签剥离
> - `_strip_think` 方法：正则匹配 `` 和 `CRETIRE_*` 标签

### 更改前后对比截图 / Screenshots

> 修改前 / Before:
> - 开启「删除思维链」后，所有轮次的思维链都被删除，用户完全看不到推理过程
> - 或关闭「删除思维链」后，每轮都显示思维链，信息冗余
>
<img width="831" height="868" alt="image" src="https://github.com/user-attachments/assets/c429d66c-652c-4214-ac9f-a1b55f0cfeb8" />

> 修改后 / After:
> - 开启「删除思维链」+「仅保留第一条思维链」后，第一轮显示思维链（推理过程可见），后续轮次仅显示实际回复内容
> - 多轮内容在同一个流式消息气泡中展示
<img width="835" height="600" alt="image" src="https://github.com/user-attachments/assets/4a353ad2-5008-4f49-9ff1-4e2c597f3da3" />

## 检查清单 / Checklist

### PR 作者完成 / For PR author

*请在方括号间写`x`以打勾 / Please tick the box with `x`*

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [x] 我已签署或将在机器人提示后签署 [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。 / I have signed, or will sign when prompted by the bot, the [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md).
- [x] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] 文档编写了吗？ / Have you written the documentation?
