### PR TITLE
fix: skip valkey-glide on Windows

### DIFF
--- a/docs/VALKEY_SEARCH_INTEGRATION.md
+++ b/docs/VALKEY_SEARCH_INTEGRATION.md
@@ -31,8 +31,10 @@ Both are compatible with LangBot.
 
 ## Installation
 
-Valkey Search support is included when you install LangBot — the `valkey-glide` dependency is
-declared in `pyproject.toml`. To install manually:
+Valkey Search support is included automatically on Linux and macOS. The official `valkey-glide`
+client does not currently publish a Windows package, so LangBot skips this optional dependency on
+Windows; LangBot remains usable there, but the Valkey Search backend is unavailable. To install the
+client manually on a supported platform:
 
 ```bash
 pip install 'valkey-glide>=2.4.1,<3.0.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "pgvector>=0.4.1",
     "botocore>=1.42.39",
     "litellm>=1.0.0",
-    "valkey-glide>=2.4.1,<3.0.0",
+    "valkey-glide>=2.4.1,<3.0.0; sys_platform != 'win32'", # No Windows wheels are published
 ]
 keywords = [
     "bot",

--- a/src/langbot/pkg/vector/vdbs/valkey_search.py
+++ b/src/langbot/pkg/vector/vdbs/valkey_search.py
@@ -119,7 +119,7 @@ class ValkeySearchVectorDatabase(VectorDatabase):
     def __init__(self, ap: app.Application):
         if not VALKEY_SEARCH_AVAILABLE:
             raise ImportError(
-                "valkey-glide is not installed or is unavailable on this platform. "
+                'valkey-glide is not installed or is unavailable on this platform. '
                 "On Linux or macOS, install it with: pip install 'valkey-glide>=2.4.1,<3.0.0'"
             )
 

--- a/src/langbot/pkg/vector/vdbs/valkey_search.py
+++ b/src/langbot/pkg/vector/vdbs/valkey_search.py
@@ -119,7 +119,8 @@ class ValkeySearchVectorDatabase(VectorDatabase):
     def __init__(self, ap: app.Application):
         if not VALKEY_SEARCH_AVAILABLE:
             raise ImportError(
-                "valkey-glide is not installed. Install it with: pip install 'valkey-glide>=2.4.1,<3.0.0'"
+                "valkey-glide is not installed or is unavailable on this platform. "
+                "On Linux or macOS, install it with: pip install 'valkey-glide>=2.4.1,<3.0.0'"
             )
 
         self.ap = ap

--- a/tests/integration/vector/test_valkey_search.py
+++ b/tests/integration/vector/test_valkey_search.py
@@ -77,10 +77,11 @@ async def backend(valkey_config):
         ValkeySearchVectorDatabase,
         VALKEY_SEARCH_AVAILABLE,
     )
-    from glide import ft
 
     if not VALKEY_SEARCH_AVAILABLE:
         pytest.skip('valkey-glide not installed')
+
+    from glide import ft
 
     ap = _make_ap(valkey_config)
     db = ValkeySearchVectorDatabase(ap)

--- a/tests/unit_tests/vector/test_valkey_search_filter.py
+++ b/tests/unit_tests/vector/test_valkey_search_filter.py
@@ -357,10 +357,13 @@ class TestCredentialsBuild:
             cred_calls.append(kwargs)
             return ('CRED', kwargs)
 
-        monkeypatch.setattr(mod, 'GlideClient', _FakeClient)
-        monkeypatch.setattr(mod, 'ServerCredentials', _fake_credentials)
-        monkeypatch.setattr(mod, 'GlideClientConfiguration', lambda **kw: kw)
-        monkeypatch.setattr(mod, 'NodeAddress', lambda *a, **k: ('node', a, k))
+        # These names are absent when the optional valkey-glide dependency is
+        # unavailable (for example, on Windows), so allow the test doubles to
+        # create them on the module.
+        monkeypatch.setattr(mod, 'GlideClient', _FakeClient, raising=False)
+        monkeypatch.setattr(mod, 'ServerCredentials', _fake_credentials, raising=False)
+        monkeypatch.setattr(mod, 'GlideClientConfiguration', lambda **kw: kw, raising=False)
+        monkeypatch.setattr(mod, 'NodeAddress', lambda *a, **k: ('node', a, k), raising=False)
         return backend, created, cred_calls, warnings
 
     async def test_username_without_password_fails_closed(self, monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -2084,7 +2084,7 @@ dependencies = [
     { name = "tiktoken" },
     { name = "urllib3" },
     { name = "uv" },
-    { name = "valkey-glide" },
+    { name = "valkey-glide", marker = "sys_platform != 'win32'" },
     { name = "websockets" },
 ]
 
@@ -2173,7 +2173,7 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.9.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uv", specifier = ">=0.11.15" },
-    { name = "valkey-glide", specifier = ">=2.4.1,<3.0.0" },
+    { name = "valkey-glide", marker = "sys_platform != 'win32'", specifier = ">=2.4.1,<3.0.0" },
     { name = "websockets", specifier = ">=15.0.1" },
 ]
 
@@ -5991,9 +5991,9 @@ name = "valkey-glide"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "protobuf" },
-    { name = "sniffio" },
+    { name = "anyio", marker = "sys_platform != 'win32'" },
+    { name = "protobuf", marker = "sys_platform != 'win32'" },
+    { name = "sniffio", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/a2/582b34c6acc8dc857c537f6007459cba48dfa0dc404789a657e5c1a998c0/valkey_glide-2.4.1.tar.gz", hash = "sha256:f1155d84156d11b90488aa67e90102f0bf98a45314f5b99308ac9074c05f7241", size = 898030, upload-time = "2026-05-28T21:41:55.881Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- mark `valkey-glide` as a non-Windows dependency and refresh `uv.lock`
- keep the Valkey Search backend optional when the client is unavailable
- make Valkey tests skip safely without `glide` and document Windows support

## Root cause

The Valkey Search integration added `valkey-glide` as an unconditional direct dependency. The published package provides macOS and manylinux wheels but no Windows wheel, so Windows installs fall back to a source build and fail.

## Impact

LangBot can be installed normally on Windows without `valkey-glide`. The Valkey Search backend remains automatically available on supported platforms and reports a clear error if selected where the client is unavailable.

## Validation

- `uv lock --check`
- Windows dependency resolution excludes `valkey-glide`
- Linux dependency resolution includes `valkey-glide`
- `45 passed, 10 skipped` for the related vector tests
- `ruff check` on the changed Python files
- `git diff --cached --check`