### PR TITLE
fix(dingtalk): avoid blocking event loop on connection open

### DIFF
--- a/src/langbot/libs/dingtalk_api/api.py
+++ b/src/langbot/libs/dingtalk_api/api.py
@@ -885,7 +885,10 @@ class DingTalkClient:
 
         while not self._stopped:
             try:
-                connection = self.client.open_connection()
+                # open_connection performs blocking network I/O in the DingTalk SDK.
+                # Run it off the event loop so connection stalls do not block the
+                # LangBot HTTP server and other async tasks.
+                connection = await asyncio.to_thread(self.client.open_connection)
 
                 if not connection:
                     if self.logger:


### PR DESCRIPTION
## Summary
- move DingTalk `open_connection()` into `asyncio.to_thread()` so SDK connection stalls do not block LangBot's event loop
- preserve the existing retry behavior and connection handling

## Why
`DingTalkStreamClient.open_connection()` performs blocking network I/O. When DingTalk endpoints are unreachable or slow, calling it directly inside the async start loop can block unrelated HTTP requests handled by LangBot.

## Validation
- `python3 -m py_compile src/langbot/libs/dingtalk_api/api.py`
- `git diff --check`