### PR TITLE
chore(release): bump version to 4.10.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot"
-version = "4.10.5"
+version = "4.10.6"
 description = "Production-grade platform for building agentic IM bots"
 readme = "README.md"
 license-files = ["LICENSE"]

--- a/uv.lock
+++ b/uv.lock
@@ -2008,7 +2008,7 @@ wheels = [
 
 [[package]]
 name = "langbot"
-version = "4.10.5"
+version = "4.10.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiocqhttp" },


### PR DESCRIPTION
## Summary
- bump the LangBot package version from 4.10.5 to 4.10.6
- refresh the root package entry in uv.lock

## Verification
- uv lock
- parsed pyproject.toml and uv.lock to confirm both report 4.10.6
- git diff --check