### PR TITLE
fix(mcp): add 30s timeout to prevent MCP tool calls from hanging indefinitely

### DIFF
--- a/src/langbot/pkg/provider/tools/loaders/mcp.py
+++ b/src/langbot/pkg/provider/tools/loaders/mcp.py
@@ -950,7 +950,12 @@ class RuntimeMCPSession:
                 raise Exception('MCP session is not connected')
 
             try:
-                result = await self.session.call_tool(tool_name, arguments)
+                async with asyncio.timeout(30):
+                    result = await self.session.call_tool(tool_name, arguments)
+            except TimeoutError as e:
+                raise Exception(
+                    f"MCP tool '{tool_name}' on server '{self.server_name}' timed out after 30 seconds"
+                ) from e
             except Exception as e:
                 if attempt == 0 and self._is_session_terminated(e):
                     self.ap.logger.warning(


### PR DESCRIPTION
## What changed

Wrapped `self.session.call_tool()` in `RuntimeMCPSession.invoke_mcp_tool()`
with `asyncio.timeout(30)` so an unresponsive MCP server no longer blocks
the entire session indefinitely.

## Why

MCP tool calls have no timeout. When an MCP server hangs, `call_tool()`
blocks forever. Combined with `concurrency.session: 1`, this locks the
entire session — all subsequent messages are dropped until manual
container restart.

Real-world incident: 9-hour outage on 2026-07-14 caused by a hung
`web_fetch` MCP call (see #2339 for full timeline).

## What specifically

- One `asyncio.timeout(30)` context manager around the existing
  `call_tool()` invocation
- `TimeoutError` caught before the existing `Exception` handler so it is
  NOT retried (a timed-out server is unlikely to recover within 30s)
- Preserves the original exception chain via `from e`
- Raises a descriptive `Exception` so the LLM can inform the user
- No other logic changed: method signature, session-terminated retry loop,
  result processing — all untouched

## Validation

```bash
uv run pytest tests/unit_tests/provider/ -q    # 322 passed
uv run ruff check .                             # All checks passed
uv run ruff format src --check                  # 403 files already formatted
uv run mypy src/langbot                         # 0 new errors
```

Existing MCP tool calls that complete within 30s are unaffected.

Closes #2339
