### PR TITLE
fix(web): show Page component icon on plugin cards

### DIFF
--- a/web/src/app/home/plugins/components/plugin-market/PluginComponentIcons.ts
+++ b/web/src/app/home/plugins/components/plugin-market/PluginComponentIcons.ts
@@ -1,0 +1,18 @@
+import {
+  AppWindow,
+  AudioWaveform,
+  Book,
+  FileText,
+  Hash,
+  Wrench,
+  type LucideIcon,
+} from 'lucide-react';
+
+export const pluginComponentIconMap: Record<string, LucideIcon> = {
+  Tool: Wrench,
+  EventListener: AudioWaveform,
+  Command: Hash,
+  KnowledgeEngine: Book,
+  Parser: FileText,
+  Page: AppWindow,
+};

--- a/web/src/app/home/plugins/components/plugin-market/PluginComponentList.tsx
+++ b/web/src/app/home/plugins/components/plugin-market/PluginComponentList.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { TFunction } from 'i18next';
-import { Wrench, AudioWaveform, Hash, Book, FileText } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { pluginComponentIconMap } from './PluginComponentIcons';
 
 export default function PluginComponentList({
   components,
@@ -18,14 +18,6 @@ export default function PluginComponentList({
   t: TFunction;
   responsive?: boolean;
 }) {
-  const kindIconMap: Record<string, React.ReactNode> = {
-    Tool: <Wrench className="w-5 h-5" />,
-    EventListener: <AudioWaveform className="w-5 h-5" />,
-    Command: <Hash className="w-5 h-5" />,
-    KnowledgeEngine: <Book className="w-5 h-5" />,
-    Parser: <FileText className="w-5 h-5" />,
-  };
-
   const componentKindList = Object.keys(components || {});
 
   return (
@@ -34,11 +26,12 @@ export default function PluginComponentList({
       {componentKindList.length > 0 && (
         <>
           {componentKindList.map((kind) => {
+            const ComponentIcon = pluginComponentIconMap[kind];
             return (
               <Fragment key={kind}>
                 {useBadge && (
                   <Badge variant="outline" className="flex items-center gap-1">
-                    {kindIconMap[kind]}
+                    {ComponentIcon && <ComponentIcon className="w-5 h-5" />}
                     {responsive ? (
                       <span className="hidden md:inline">
                         {t('market.componentName.' + kind)}
@@ -52,7 +45,7 @@ export default function PluginComponentList({
 
                 {!useBadge && (
                   <div className="flex flex-row items-center justify-start gap-[0.2rem]">
-                    {kindIconMap[kind]}
+                    {ComponentIcon && <ComponentIcon className="w-5 h-5" />}
                     {responsive ? (
                       <span className="hidden md:inline">
                         {t('market.componentName.' + kind)}

--- a/web/tests/unit/plugin-component-icons.test.mjs
+++ b/web/tests/unit/plugin-component-icons.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const sourcePath = path.resolve(
+  currentDirectory,
+  '../../src/app/home/plugins/components/plugin-market/PluginComponentIcons.ts',
+);
+const source = fs.readFileSync(sourcePath, 'utf8');
+const compiled = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.CommonJS },
+}).outputText;
+const sourceRequire = createRequire(sourcePath);
+const loadedModule = { exports: {} };
+new Function('require', 'module', 'exports', compiled)(
+  sourceRequire,
+  loadedModule,
+  loadedModule.exports,
+);
+
+const { AppWindow } = sourceRequire('lucide-react');
+const { pluginComponentIconMap } = loadedModule.exports;
+
+test('maps the Page plugin component to the AppWindow icon', () => {
+  assert.equal(pluginComponentIconMap.Page, AppWindow);
+});


### PR DESCRIPTION
## Root cause

The marketplace filter already represents the `Page` component with Lucide `AppWindow`, but `PluginComponentList` omitted `Page` from its icon map. Page-only badges therefore rendered the count without an icon.

## Fix

- centralize marketplace component icons in a typed map
- map `Page` to `AppWindow`, matching the component filter
- render mapped Lucide components in both badge and non-badge variants
- add a focused regression test for the Page icon mapping

## Verification

- `node --test tests/unit/plugin-component-icons.test.mjs`
- targeted ESLint passed
- targeted Prettier check passed
- `git diff --check` passed