### PR TITLE
feat(platform): pass original image URL to Image component in 6 adapters

### DIFF
--- a/src/langbot/pkg/platform/sources/aiocqhttp.py
+++ b/src/langbot/pkg/platform/sources/aiocqhttp.py
@@ -240,7 +240,11 @@ class AiocqhttpMessageConverter(abstract_platform_adapter.AbstractMessageConvert
         async def process_message_data(msg_data, reply_list):
             if msg_data['type'] == 'image':
                 image_base64, image_format = await image.qq_image_url_to_base64(msg_data['data']['url'])
-                reply_list.append(platform_message.Image(base64=f'data:image/{image_format};base64,{image_base64}'))
+                reply_list.append(
+                    platform_message.Image(
+                        url=msg_data['data']['url'], base64=f'data:image/{image_format};base64,{image_base64}'
+                    )
+                )
 
             elif msg_data['type'] == 'text':
                 reply_list.append(platform_message.Plain(text=msg_data['data']['text']))
@@ -285,7 +289,9 @@ class AiocqhttpMessageConverter(abstract_platform_adapter.AbstractMessageConvert
                     image_msg = platform_message.Face(face_id=face_id, face_name=face_name)
                 else:
                     image_base64, image_format = await image.qq_image_url_to_base64(msg.data['url'])
-                    image_msg = platform_message.Image(base64=f'data:image/{image_format};base64,{image_base64}')
+                    image_msg = platform_message.Image(
+                        url=msg.data['url'], base64=f'data:image/{image_format};base64,{image_base64}'
+                    )
                 yiri_msg_list.append(image_msg)
             elif msg.type == 'forward':
                 # 暂时不太合理

--- a/src/langbot/pkg/platform/sources/discord.py
+++ b/src/langbot/pkg/platform/sources/discord.py
@@ -783,7 +783,9 @@ class DiscordMessageConverter(abstract_platform_adapter.AbstractMessageConverter
                 image_data = await response.read()
                 image_base64 = base64.b64encode(image_data).decode('utf-8')
                 image_format = response.headers['Content-Type']
-                element_list.append(platform_message.Image(base64=f'data:{image_format};base64,{image_base64}'))
+                element_list.append(
+                    platform_message.Image(url=attachment.url, base64=f'data:{image_format};base64,{image_base64}')
+                )
 
         return platform_message.MessageChain(element_list)
 

--- a/src/langbot/pkg/platform/sources/qqofficial.py
+++ b/src/langbot/pkg/platform/sources/qqofficial.py
@@ -102,7 +102,7 @@ class QQOfficialMessageConverter(abstract_platform_adapter.AbstractMessageConver
         yiri_msg_list.append(platform_message.Source(id=message_id, time=datetime.datetime.now()))
         if pic_url is not None:
             base64_url = await image.get_qq_official_image_base64(pic_url=pic_url, content_type=content_type)
-            yiri_msg_list.append(platform_message.Image(base64=base64_url))
+            yiri_msg_list.append(platform_message.Image(url=pic_url, base64=base64_url))
 
         yiri_msg_list.append(platform_message.Plain(text=message))
         chain = platform_message.MessageChain(yiri_msg_list)

--- a/src/langbot/pkg/platform/sources/slack.py
+++ b/src/langbot/pkg/platform/sources/slack.py
@@ -47,7 +47,7 @@ class SlackMessageConverter(abstract_platform_adapter.AbstractMessageConverter):
         yiri_msg_list.append(platform_message.Source(id=message_id, time=datetime.datetime.now()))
         if pic_url is not None:
             base64_url = await image.get_slack_image_to_base64(pic_url=pic_url, bot_token=bot.bot_token)
-            yiri_msg_list.append(platform_message.Image(base64=base64_url))
+            yiri_msg_list.append(platform_message.Image(url=pic_url, base64=base64_url))
 
         yiri_msg_list.append(platform_message.Plain(text=message))
         chain = platform_message.MessageChain(yiri_msg_list)

--- a/src/langbot/pkg/platform/sources/telegram.py
+++ b/src/langbot/pkg/platform/sources/telegram.py
@@ -157,7 +157,8 @@ class TelegramMessageConverter(abstract_platform_adapter.AbstractMessageConverte
 
             message_components.append(
                 platform_message.Image(
-                    base64=f'data:{file_format};base64,{base64.b64encode(file_bytes).decode("utf-8")}'
+                    url=file.file_path,
+                    base64=f'data:{file_format};base64,{base64.b64encode(file_bytes).decode("utf-8")}',
                 )
             )
 

--- a/src/langbot/pkg/platform/sources/wecom.py
+++ b/src/langbot/pkg/platform/sources/wecom.py
@@ -133,7 +133,9 @@ class WecomMessageConverter(abstract_platform_adapter.AbstractMessageConverter):
         yiri_msg_list = []
         yiri_msg_list.append(platform_message.Source(id=message_id, time=datetime.datetime.now()))
         image_base64, image_format = await image.get_wecom_image_base64(pic_url=picurl)
-        yiri_msg_list.append(platform_message.Image(base64=f'data:image/{image_format};base64,{image_base64}'))
+        yiri_msg_list.append(
+            platform_message.Image(url=picurl, base64=f'data:image/{image_format};base64,{image_base64}')
+        )
         chain = platform_message.MessageChain(yiri_msg_list)
 
         return chain


### PR DESCRIPTION
## Summary

Preserve the platform CDN URL in `Image.url` alongside `base64` data in 6 platform adapters. This enables plugins to use `ContentElement.from_image_url()` for direct vision API access without redundant local download.

Satori adapter already follows this pattern (`satori.py:168`). This PR brings the other adapters in line.

## Changes

| Adapter | URL source | Lines |
|---------|-----------|-------|
| `aiocqhttp.py` | `msg_data["data"]["url"]` / `msg.data["url"]` | 243, 288 |
| `discord.py` | `attachment.url` | 786 |
| `telegram.py` | `file.file_path` | 159 |
| `slack.py` | `pic_url` | 50 |
| `wecom.py` | `picurl` | 136 |
| `qqofficial.py` | `pic_url` | 105 |

Each URL is the same value already used for downloading the image in the same or preceding line — no new data source is introduced.

## Why not lark.py?

lark.py L702 receives images via Lark API `image_key` (not URL), so it is excluded. lark.py L533 (sending) already passes `url=url` correctly.

## Backward compatibility

- **Purely additive**: `base64=` is preserved in all cases. Existing plugins are unaffected.
- **Safe priority chain**: `Image.get_bytes()` → `url → base64 → path`. URL takes priority when valid, falls back to base64 when expired.
- **SDK field**: `Image.url` is an official SDK field (`langbot_plugin.api.entities.builtin.platform.message.Image`, default `""`).

## Benefits

| Dimension | Before | After |
|-----------|--------|-------|
| Image downloads | 2× (adapter + plugin) | 0–1× (vision API reads CDN directly) |
| WS transfer per image | ~150KB (base64) | ~200B (url) + base64 |
| Plugin processing | download + resize + base64-encode | one-line `from_image_url()` |

## Testing

- **aiocqhttp** ✅: Production-validated (LangBot v4.10.5 + NapCat QQ, 100% `url_ok` over multiple days). PR branch deployed and smoke-tested on 2026-07-28 — vision recognition confirmed working (`url_ok lat=20.6s`).
- **discord / telegram / slack / wecom / qqofficial** ⬜: Equivalence reasoning — each URL variable is the exact same value used for HTTP download in the adjacent line. Not tested in production (maintainer/community verification welcome).

## Checklist

- [x] Read CONTRIBUTING.md
- [x] Communicated with maintainer (issue #2355)
- [x] `ruff format` + `ruff check` pass
- [ ] CLA signing (first-time contributor — will follow bot instructions)

Closes #2355

🤖 Generated with [Claude Code](https://claude.com/claude-code)