### PR TITLE
fix(websocket): prevent cross-pipeline Debug Chat reply leaks under concurrent messages

### DIFF
--- a/src/langbot/pkg/platform/botmgr.py
+++ b/src/langbot/pkg/platform/botmgr.py
@@ -229,9 +229,21 @@ class RuntimeBot:
 
                 message_text = str(event.message_chain)
                 element_types = [comp.type for comp in event.message_chain]
-                pipeline_uuid, routed_by_rule = self.resolve_pipeline_uuid(
-                    'person', launcher_id, message_text, element_types
-                )
+
+                # Adapters that bind a launcher to one pipeline at connect time
+                # (e.g. the WebSocket debug/embed adapter) resolve it from the
+                # event itself, so concurrent messages for different pipelines
+                # don't race on the shared use_pipeline_uuid field (#2286).
+                event_pipeline_uuid = None
+                if hasattr(adapter, 'get_event_pipeline_uuid'):
+                    event_pipeline_uuid = adapter.get_event_pipeline_uuid(event)
+
+                if event_pipeline_uuid:
+                    pipeline_uuid, routed_by_rule = event_pipeline_uuid, False
+                else:
+                    pipeline_uuid, routed_by_rule = self.resolve_pipeline_uuid(
+                        'person', launcher_id, message_text, element_types
+                    )
 
                 if pipeline_uuid == self.PIPELINE_DISCARD:
                     await self.logger.info('Person message discarded by routing rule')
@@ -290,9 +302,19 @@ class RuntimeBot:
 
                 message_text = str(event.message_chain)
                 element_types = [comp.type for comp in event.message_chain]
-                pipeline_uuid, routed_by_rule = self.resolve_pipeline_uuid(
-                    'group', launcher_id, message_text, element_types
-                )
+
+                # Same request-local pipeline resolution as person messages;
+                # see the comment in on_friend_message (#2286).
+                event_pipeline_uuid = None
+                if hasattr(adapter, 'get_event_pipeline_uuid'):
+                    event_pipeline_uuid = adapter.get_event_pipeline_uuid(event)
+
+                if event_pipeline_uuid:
+                    pipeline_uuid, routed_by_rule = event_pipeline_uuid, False
+                else:
+                    pipeline_uuid, routed_by_rule = self.resolve_pipeline_uuid(
+                        'group', launcher_id, message_text, element_types
+                    )
 
                 if pipeline_uuid == self.PIPELINE_DISCARD:
                     await self.logger.info('Group message discarded by routing rule')

--- a/src/langbot/pkg/platform/sources/web_page_bot_adapter.py
+++ b/src/langbot/pkg/platform/sources/web_page_bot_adapter.py
@@ -36,6 +36,12 @@ class WebPageBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter
         """Set the underlying WebSocket adapter used for actual message delivery."""
         object.__setattr__(self, '_ws_adapter', ws_adapter)
 
+    def get_event_pipeline_uuid(self, event: platform_events.MessageEvent) -> str | None:
+        """Delegate request-local pipeline resolution to the WebSocket adapter."""
+        if self._ws_adapter is not None:
+            return self._ws_adapter.get_event_pipeline_uuid(event)
+        return None
+
     async def send_message(
         self,
         target_type: str,

--- a/src/langbot/pkg/platform/sources/websocket_adapter.py
+++ b/src/langbot/pkg/platform/sources/websocket_adapter.py
@@ -17,6 +17,9 @@ from .websocket_manager import WebSocketConnection, is_valid_session_id, ws_conn
 
 logger = logging.getLogger(__name__)
 
+MAX_REMEMBERED_CONNECTION_ROUTES = 512
+"""Upper bound for the connection→pipeline route memory used by late replies."""
+
 
 class WebSocketMessage(pydantic.BaseModel):
     """WebSocket消息格式"""
@@ -77,6 +80,15 @@ class WebSocketAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter)
     stream_enabled: bool = pydantic.Field(default=True, exclude=True)
     """是否启用流式输出"""
 
+    _connection_pipeline_routes: dict = pydantic.PrivateAttr(default_factory=dict)
+    """最近的连接到流水线映射 {connection_id: pipeline_uuid}
+
+    Retained after a connection closes so that late replies (e.g. streamed
+    chunks that finish after the client disconnected) still route to the
+    pipeline that owned the request instead of falling back to the mutable
+    singleton ``use_pipeline_uuid`` field.
+    """
+
     def __init__(self, config: dict, logger: abstract_platform_logger.AbstractEventLogger, **kwargs):
         super().__init__(
             config=config,
@@ -97,16 +109,19 @@ class WebSocketAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter)
         return f'{pipeline_uuid}:{session_id}' if session_id else pipeline_uuid
 
     @staticmethod
-    def _parse_embed_target(target_id: str) -> tuple[str, str] | None:
-        """Extract pipeline and session identifiers from a stable embed launcher."""
+    def _strip_launcher_prefix(target_id: str) -> str | None:
+        """Strip the person/group launcher prefix, or None if not a WS launcher."""
         target_value = str(target_id)
         for prefix in ('websocket_', 'websocketgroup_'):
             if target_value.startswith(prefix):
-                target = target_value[len(prefix) :]
-                break
-        else:
-            return None
-        if ':' not in target:
+                return target_value[len(prefix) :]
+        return None
+
+    @classmethod
+    def _parse_embed_target(cls, target_id: str) -> tuple[str, str] | None:
+        """Extract pipeline and session identifiers from a stable embed launcher."""
+        target = cls._strip_launcher_prefix(target_id)
+        if target is None or ':' not in target:
             return None
         pipeline_uuid, session_id = target.rsplit(':', 1)
         if not pipeline_uuid or not is_valid_session_id(session_id):
@@ -116,12 +131,8 @@ class WebSocketAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter)
     @classmethod
     async def _get_connection_from_target(cls, target_id: str):
         """Resolve a person or group WebSocket launcher to its connection."""
-        target_value = str(target_id)
-        for prefix in ('websocket_', 'websocketgroup_'):
-            if target_value.startswith(prefix):
-                target = target_value[len(prefix) :]
-                break
-        else:
+        target = cls._strip_launcher_prefix(target_id)
+        if target is None:
             return None
         connection = await ws_connection_manager.get_connection(target)
         if connection is not None:
@@ -131,6 +142,42 @@ class WebSocketAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter)
             pipeline_uuid, session_id = embed_target
             return await ws_connection_manager.get_connection_by_session_id(session_id, pipeline_uuid)
         return await ws_connection_manager.get_connection_by_session_id(target)
+
+    def _remember_connection_route(self, connection: WebSocketConnection):
+        """Record which pipeline owns a connection, keeping the memory bounded."""
+        routes = self._connection_pipeline_routes
+        routes.pop(connection.connection_id, None)
+        routes[connection.connection_id] = connection.pipeline_uuid
+        while len(routes) > MAX_REMEMBERED_CONNECTION_ROUTES:
+            routes.pop(next(iter(routes)))
+
+    def _remembered_pipeline_for_target(self, target_id: str) -> str | None:
+        """Look up the retained route for a launcher whose connection is gone."""
+        target = self._strip_launcher_prefix(target_id)
+        if target is None:
+            return None
+        return self._connection_pipeline_routes.get(target)
+
+    def get_event_pipeline_uuid(self, event: platform_events.MessageEvent) -> str | None:
+        """Resolve the pipeline that owns an inbound WebSocket event.
+
+        Debug Chat and embed launcher ids are bound to exactly one pipeline
+        when the connection is established, so the pipeline can be derived
+        from the event itself. PlatformManager prefers this request-local
+        hint over the shared ``use_pipeline_uuid`` field, which concurrent
+        messages for different pipelines would otherwise race on.
+        """
+        sender_id = str(getattr(getattr(event, 'sender', None), 'id', '') or '')
+        target = self._strip_launcher_prefix(sender_id)
+        if target is None:
+            return None
+        connection = ws_connection_manager.connections.get(target)
+        if connection is not None:
+            return connection.pipeline_uuid
+        embed_target = self._parse_embed_target(sender_id)
+        if embed_target is not None:
+            return embed_target[0]
+        return self._connection_pipeline_routes.get(target)
 
     async def _get_message_context(self, message_source) -> tuple[str, str | None]:
         """Resolve the originating pipeline and browser session for a reply."""
@@ -142,6 +189,9 @@ class WebSocketAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter)
         embed_target = self._parse_embed_target(sender_id)
         if embed_target is not None:
             return embed_target
+        remembered = self._remembered_pipeline_for_target(str(sender_id))
+        if remembered is not None:
+            return remembered, None
         return typing.cast(str, self.ap.platform_mgr.websocket_proxy_bot.bot_entity.use_pipeline_uuid), None
 
     async def send_message(
@@ -165,7 +215,8 @@ class WebSocketAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter)
             if embed_target is not None:
                 pipeline_uuid, session_id = embed_target
             else:
-                pipeline_uuid = typing.cast(
+                remembered = self._remembered_pipeline_for_target(str(target_id))
+                pipeline_uuid = remembered or typing.cast(
                     str,
                     self.ap.platform_mgr.websocket_proxy_bot.bot_entity.use_pipeline_uuid,
                 )
@@ -445,6 +496,8 @@ class WebSocketAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter)
         session_type = connection.session_type
         conversation_key = self._conversation_key(pipeline_uuid, connection.session_id)
 
+        self._remember_connection_route(connection)
+
         self.stream_enabled = message_data.get('stream', True)
 
         use_session = self.websocket_group_session if session_type == 'group' else self.websocket_person_session
@@ -506,7 +559,9 @@ class WebSocketAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter)
                 sender=sender, message_chain=message_chain, time=datetime.now().timestamp()
             )
 
-        # 设置流水线UUID (proxy bot always needs it for reply_message routing)
+        # Legacy last-resort fallback only: per-request routing is resolved from
+        # the event via get_event_pipeline_uuid / the connection registry, since
+        # this shared field races under concurrent messages (#2286).
         self.ap.platform_mgr.websocket_proxy_bot.bot_entity.use_pipeline_uuid = pipeline_uuid
         if owner_bot is not None:
             owner_bot.bot_entity.use_pipeline_uuid = pipeline_uuid

--- a/tests/unit_tests/platform/test_websocket_pipeline_isolation.py
+++ b/tests/unit_tests/platform/test_websocket_pipeline_isolation.py
@@ -1,0 +1,162 @@
+"""Regression tests for cross-pipeline Debug Chat isolation (#2286).
+
+Debug Chat routing must stay request-local: concurrent messages for
+different pipelines must not race on the mutable singleton
+``websocket_proxy_bot.bot_entity.use_pipeline_uuid`` field.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+import langbot_plugin.api.entities.builtin.platform.events as platform_events
+from langbot.pkg.platform.sources import websocket_adapter as websocket_adapter_module
+from langbot.pkg.platform.sources.websocket_adapter import (
+    MAX_REMEMBERED_CONNECTION_ROUTES,
+    WebSocketAdapter,
+    WebSocketSession,
+)
+from langbot.pkg.platform.sources.websocket_manager import WebSocketConnectionManager
+
+
+def _make_adapter() -> WebSocketAdapter:
+    adapter = WebSocketAdapter.model_construct(ap=Mock(), logger=AsyncMock())
+    adapter.websocket_person_session = WebSocketSession(id='person')
+    adapter.websocket_group_session = WebSocketSession(id='group')
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_concurrent_dashboard_events_resolve_their_own_pipeline(monkeypatch):
+    manager = WebSocketConnectionManager()
+    connection_a = await manager.add_connection(
+        websocket=Mock(),
+        pipeline_uuid='pipeline-a',
+        session_type='person',
+    )
+    connection_b = await manager.add_connection(
+        websocket=Mock(),
+        pipeline_uuid='pipeline-b',
+        session_type='person',
+    )
+    monkeypatch.setattr(websocket_adapter_module, 'ws_connection_manager', manager)
+
+    adapter = _make_adapter()
+    received = []
+
+    async def listener(event, _callback_adapter):
+        received.append(event)
+
+    adapter.listeners = {platform_events.FriendMessage: listener}
+
+    # Interleave two messages before either listener task runs, mimicking the
+    # concurrent WebSocket messages from the cross-pipeline isolation QA case.
+    await adapter.handle_websocket_message(
+        connection_a,
+        {'message': [{'type': 'Plain', 'text': 'PIPEA-token'}], 'stream': False},
+    )
+    await adapter.handle_websocket_message(
+        connection_b,
+        {'message': [{'type': 'Plain', 'text': 'PIPEB-token'}], 'stream': False},
+    )
+    await asyncio.sleep(0)
+
+    # The singleton field now holds pipeline-b, but each event must still
+    # resolve to the pipeline of the connection it arrived on.
+    assert adapter.ap.platform_mgr.websocket_proxy_bot.bot_entity.use_pipeline_uuid == 'pipeline-b'
+    assert len(received) == 2
+    assert adapter.get_event_pipeline_uuid(received[0]) == 'pipeline-a'
+    assert adapter.get_event_pipeline_uuid(received[1]) == 'pipeline-b'
+
+
+@pytest.mark.asyncio
+async def test_group_dashboard_event_resolves_pipeline(monkeypatch):
+    manager = WebSocketConnectionManager()
+    connection = await manager.add_connection(
+        websocket=Mock(),
+        pipeline_uuid='pipeline-a',
+        session_type='group',
+    )
+    monkeypatch.setattr(websocket_adapter_module, 'ws_connection_manager', manager)
+
+    adapter = _make_adapter()
+    received = []
+
+    async def listener(event, _callback_adapter):
+        received.append(event)
+
+    adapter.listeners = {platform_events.GroupMessage: listener}
+    await adapter.handle_websocket_message(
+        connection,
+        {'message': [{'type': 'Plain', 'text': 'hello'}], 'stream': False},
+    )
+    await asyncio.sleep(0)
+
+    assert adapter.get_event_pipeline_uuid(received[0]) == 'pipeline-a'
+
+
+def test_embed_event_resolves_pipeline_without_live_connection(monkeypatch):
+    monkeypatch.setattr(websocket_adapter_module, 'ws_connection_manager', WebSocketConnectionManager())
+
+    adapter = _make_adapter()
+    event = Mock()
+    event.sender.id = 'websocket_pipeline-1:31c0f2e9-b115-4ee6-8f15-3e624d6456b1'
+
+    assert adapter.get_event_pipeline_uuid(event) == 'pipeline-1'
+
+
+def test_non_websocket_event_returns_no_pipeline_hint(monkeypatch):
+    monkeypatch.setattr(websocket_adapter_module, 'ws_connection_manager', WebSocketConnectionManager())
+
+    adapter = _make_adapter()
+    event = Mock()
+    event.sender.id = '12345678'
+
+    assert adapter.get_event_pipeline_uuid(event) is None
+
+
+@pytest.mark.asyncio
+async def test_reply_context_survives_connection_close(monkeypatch):
+    manager = WebSocketConnectionManager()
+    connection = await manager.add_connection(
+        websocket=Mock(),
+        pipeline_uuid='pipeline-a',
+        session_type='person',
+    )
+    monkeypatch.setattr(websocket_adapter_module, 'ws_connection_manager', manager)
+
+    adapter = _make_adapter()
+    adapter.listeners = {}
+    await adapter.handle_websocket_message(
+        connection,
+        {'message': [{'type': 'Plain', 'text': 'hello'}], 'stream': False},
+    )
+
+    # Simulate another pipeline's message overwriting the singleton field
+    # while pipeline-a's reply is still in flight.
+    adapter.ap.platform_mgr.websocket_proxy_bot.bot_entity.use_pipeline_uuid = 'pipeline-b'
+
+    message_source = Mock()
+    message_source.sender.id = f'websocket_{connection.connection_id}'
+
+    # Live connection resolves directly.
+    assert await adapter._get_message_context(message_source) == ('pipeline-a', None)
+
+    # After the client disconnects the retained route must still win over
+    # the singleton fallback, so a late reply cannot leak to pipeline-b.
+    await manager.remove_connection(connection.connection_id)
+    assert await adapter._get_message_context(message_source) == ('pipeline-a', None)
+
+
+def test_connection_route_memory_is_bounded():
+    adapter = _make_adapter()
+
+    for index in range(MAX_REMEMBERED_CONNECTION_ROUTES + 10):
+        adapter._remember_connection_route(Mock(connection_id=f'conn-{index}', pipeline_uuid=f'pipeline-{index}'))
+
+    assert len(adapter._connection_pipeline_routes) == MAX_REMEMBERED_CONNECTION_ROUTES
+    assert 'conn-0' not in adapter._connection_pipeline_routes
+    assert adapter._connection_pipeline_routes[f'conn-{MAX_REMEMBERED_CONNECTION_ROUTES + 9}'] == (
+        f'pipeline-{MAX_REMEMBERED_CONNECTION_ROUTES + 9}'
+    )


### PR DESCRIPTION
Fixes #2286

## Problem

Debug Chat stored per-message routing state on the singleton `websocket_proxy_bot.bot_entity.use_pipeline_uuid`:

- `WebSocketAdapter.handle_websocket_message` wrote the connection's `pipeline_uuid` to the singleton, then scheduled pipeline handling asynchronously.
- `PlatformManager`'s message handlers picked the pipeline via `resolve_pipeline_uuid()`, whose fallback re-reads that singleton field.
- `reply_message` / `reply_message_chunk` / `send_message` also fell back to re-reading it when the originating connection could not be resolved (e.g. a client that disconnected while a streamed reply was still in flight).

Under concurrent WebSocket messages for different pipelines, a later message overwrites the field while an earlier query is still being routed or answered — queries can run in the wrong pipeline, and replies can be broadcast to the wrong pipeline's Debug Chat connections. This matches the leaks observed by the `langbot-fake-provider-debug-chat-cross-pipeline-isolation` QA case (3 cross-pipeline leaks / 12 requests).

## Fix

Keep routing request-local, as suggested in the issue:

- **New adapter hook** `WebSocketAdapter.get_event_pipeline_uuid(event)` resolves the owning pipeline from the event's launcher id: live connection registry first, then the stable embed target, then a bounded retained `connection_id → pipeline_uuid` map. Follows the existing `get_launcher_id()` adapter-hook pattern.
- **`PlatformManager`** (person + group handlers) prefers this request-local hint over `resolve_pipeline_uuid()`'s singleton fallback. Adapters without the hook are unaffected; the dashboard debug WebSocket is bound to exactly one pipeline at connect time, so the hint is definitive there.
- **Reply paths** (`_get_message_context`, `send_message`) consult the retained route map before the singleton fallback, so late replies after a client disconnect still route to the pipeline that owned the request. The singleton write is kept only as a legacy last resort for paths outside the WebSocket flow.
- **`WebPageBotAdapter`** delegates the hook to the WebSocket adapter so embed traffic resolves identically.

No behavior change for other platform adapters, and no change to launcher id / conversation history key formats.

## Tests

- New `tests/unit_tests/platform/test_websocket_pipeline_isolation.py`:
  - concurrent dashboard messages on two pipelines each resolve to their own pipeline even after the singleton was overwritten;
  - group-session and embed launchers resolve correctly, non-WebSocket events return no hint;
  - reply context survives a client disconnect and does not fall back to the (stale) singleton;
  - the retained route map stays bounded.
- `uv run pytest tests/unit_tests -q` → 1835 passed, 1 skipped.
- `uv run ruff check` / `ruff format --check` clean on changed files.

The reproducing QA case (`bin/lbs test run langbot-fake-provider-debug-chat-cross-pipeline-isolation`) from #2283 remains the end-to-end validation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)