### PR TITLE
fix(config): preserve typed list environment overrides

### DIFF
--- a/src/langbot/pkg/core/stages/load_config.py
+++ b/src/langbot/pkg/core/stages/load_config.py
@@ -186,9 +186,14 @@ def _apply_env_overrides_to_config(cfg: dict) -> dict:
                 # At the final key
                 if key in current:
                     if isinstance(current[key], list):
-                        # Convert comma-separated string to list
-                        # e.g., SYSTEM__DISABLED_ADAPTERS="aiocqhttp,dingtalk"
-                        current[key] = [item.strip() for item in env_value.split(',') if item.strip()]
+                        # Convert comma-separated values while preserving the
+                        # element type declared by a non-empty config default.
+                        items = [item.strip() for item in env_value.split(',') if item.strip()]
+                        if current[key]:
+                            exemplar = current[key][0]
+                            current[key] = [convert_value(item, exemplar) for item in items]
+                        else:
+                            current[key] = items
                     elif isinstance(current[key], dict):
                         # Skip dict types
                         pass

--- a/tests/unit_tests/core/test_load_config.py
+++ b/tests/unit_tests/core/test_load_config.py
@@ -152,6 +152,19 @@ class TestApplyEnvOverridesToConfig:
 
         assert result['system']['disabled_adapters'] == ['aiocqhttp', 'dingtalk', 'telegram']
 
+    def test_override_integer_list_preserves_item_type(self):
+        """Comma-separated overrides inherit the existing list item type."""
+        load_config = get_load_config_module()
+
+        cfg = {'vdb': {'pgvector': {'allowed_dimensions': [384, 512]}}}
+        env = {'VDB__PGVECTOR__ALLOWED_DIMENSIONS': '384,512,768'}
+
+        with patch.dict(os.environ, env, clear=True):
+            result = load_config._apply_env_overrides_to_config(cfg)
+
+        assert result['vdb']['pgvector']['allowed_dimensions'] == [384, 512, 768]
+        assert all(isinstance(item, int) for item in result['vdb']['pgvector']['allowed_dimensions'])
+
     def test_override_list_value_empty_items(self):
         """Test that empty items in comma-separated list are filtered."""
         load_config = get_load_config_module()


### PR DESCRIPTION
## Summary
- preserve configured item types for non-empty list environment overrides
- keep existing comma-separated string-list behavior
- cover integer-list overrides used by Cloud pgvector dimensions

## Verification
- regression reproduced: numeric dimensions became strings and blocked Cloud release migration
- targeted test passed after fix
- full `test_load_config.py`: 27 passed