### PR TITLE
feat(telemetry): report workspace execution generation

### DIFF
--- a/src/langbot/pkg/telemetry/heartbeat.py
+++ b/src/langbot/pkg/telemetry/heartbeat.py
@@ -37,6 +37,7 @@ class WorkspaceResourceSnapshot(typing.TypedDict):
     extension_count: int
     skill_count: int
     adapters: list[str]
+    execution_generation: int
 
 
 async def _count(
@@ -81,6 +82,7 @@ async def _cloud_workspace_resource_counts(ap: core_app.Application, bindings) -
             'extension_count': 0,
             'skill_count': 0,
             'adapters': [],
+            'execution_generation': binding.placement_generation,
         }
         for binding in bindings
     }

--- a/tests/unit_tests/telemetry/test_heartbeat.py
+++ b/tests/unit_tests/telemetry/test_heartbeat.py
@@ -139,8 +139,8 @@ class TestBuildHeartbeatPayload:
         }
         ap.workspace_service.list_active_execution_bindings = AsyncMock(
             return_value=[
-                SimpleNamespace(workspace_uuid='workspace-a'),
-                SimpleNamespace(workspace_uuid='workspace-b'),
+                SimpleNamespace(workspace_uuid='workspace-a', placement_generation=7),
+                SimpleNamespace(workspace_uuid='workspace-b', placement_generation=9),
             ],
         )
         ap.platform_mgr._bots_by_key[('instance-a', 'workspace-b', 'bot-b')] = SimpleNamespace(
@@ -159,10 +159,12 @@ class TestBuildHeartbeatPayload:
         assert by_workspace['workspace-a']['plugin_count'] == 2
         assert by_workspace['workspace-a']['extension_count'] == 5
         assert by_workspace['workspace-a']['skill_count'] == 2
+        assert by_workspace['workspace-a']['execution_generation'] == 7
         assert by_workspace['workspace-a']['adapters'] == ['WorkspaceAAdapter']
         assert by_workspace['workspace-b']['bot_count'] == 1
         assert by_workspace['workspace-b']['pipeline_count'] == 0
         assert by_workspace['workspace-b']['skill_count'] == 1
+        assert by_workspace['workspace-b']['execution_generation'] == 9
         assert by_workspace['workspace-b']['adapters'] == ['WorkspaceBAdapter']
         assert 'workspace_resources' not in by_workspace['workspace-a']
         ap.persistence_mgr.execute_async.assert_not_awaited()


### PR DESCRIPTION
## Summary
- include each Workspace execution binding generation in managed heartbeat snapshots
- let Space compare the Core-applied generation with the control-plane generation

## Verification
- `ruff check` on changed files
- 30 telemetry unit tests passed