### PR TITLE
fix(cloud): accept null model abilities

### DIFF
--- a/src/langbot/pkg/cloud/model_catalog.py
+++ b/src/langbot/pkg/cloud/model_catalog.py
@@ -32,6 +32,11 @@ class CloudModelCatalogItem(BaseModel):
     is_featured: bool = False
     featured_order: int = 0
 
+    @field_validator('llm_abilities', mode='before')
+    @classmethod
+    def normalize_missing_abilities(cls, value: Any) -> Any:
+        return () if value is None else value
+
     @field_validator('llm_abilities')
     @classmethod
     def validate_abilities(cls, value: tuple[str, ...]) -> tuple[str, ...]:

--- a/tests/unit_tests/cloud/test_model_catalog.py
+++ b/tests/unit_tests/cloud/test_model_catalog.py
@@ -84,6 +84,15 @@ def _snapshot(
     )
 
 
+async def test_catalog_snapshot_treats_null_model_abilities_as_empty() -> None:
+    payload = _snapshot().model_dump(mode='json')
+    payload['models'][0]['llm_abilities'] = None
+
+    snapshot = CloudModelCatalogSnapshot.model_validate(payload)
+
+    assert snapshot.models[0].llm_abilities == ()
+
+
 async def test_catalog_reconciles_every_workspace_idempotently_and_tracks_owner_and_downlisting(tmp_path) -> None:
     engine = create_async_engine(f'sqlite+aiosqlite:///{tmp_path / "model-catalog.db"}')
     manager = PersistenceManager(object(), mode=PersistenceMode.CLOUD_RUNTIME)


### PR DESCRIPTION
## Summary
- normalize signed model-catalog `llm_abilities: null` to an empty tuple
- add a regression test matching the real Go nil-slice JSON payload

## Root cause
The production Space snapshot encoded models without declared abilities as JSON `null`. Core treated the field as a strict tuple and failed Cloud bootstrap with `Signed model catalog does not match the Core schema`.

## Verification
- RED: the regression test failed with `models.0.llm_abilities Input should be a valid tuple`
- GREEN: targeted test and all 7 model-catalog tests pass
- Ruff check/format pass
- candidate image plus this source overlay validates the real production signed snapshot as `VALID`
- failed candidate rollout was rolled back; production is healthy on the previous immutable image

## Safety
Only `None` is normalized. All non-null values continue through existing Pydantic tuple/item validation.