### PR TITLE
fix(cloud): treat workspace owners as Space-bound

### DIFF
--- a/src/langbot/pkg/api/http/controller/groups/user.py
+++ b/src/langbot/pkg/api/http/controller/groups/user.py
@@ -285,8 +285,17 @@ class UserRouterGroup(group.RouterGroup):
                 request_context.workspace_uuid,
             )
             owner = await self.ap.user_service.get_workspace_owner(access.workspace.uuid)
-            owner_space_bound = bool(owner and owner.space_account_uuid)
-            credits = await self.ap.space_service.get_credits(owner.user) if owner_space_bound else None
+            cloud_mode = getattr(getattr(self.ap, 'deployment', None), 'mode', 'oss') == 'cloud'
+            owner_has_local_space_credentials = bool(owner and owner.space_account_uuid)
+            # Cloud Accounts authenticate through LangBot Account, so every projected
+            # Workspace owner is already bound even when this Core has no local OAuth
+            # token row (model billing uses the owner's control-plane API key).
+            owner_space_bound = cloud_mode or owner_has_local_space_credentials
+            credits = (
+                await self.ap.space_service.get_credits(owner.user)
+                if owner is not None and owner.space_account_uuid
+                else None
+            )
             return self.success(
                 data={
                     'credits': credits,

--- a/tests/integration/api/test_user_space_oauth.py
+++ b/tests/integration/api/test_user_space_oauth.py
@@ -272,14 +272,37 @@ async def test_space_credits_are_resolved_from_workspace_owner(space_oauth_api):
         '/api/v1/user/space-credits',
         headers={'Authorization': 'Bearer account-token', 'X-Workspace-Id': WORKSPACE_UUID},
     )
+    payload = await response.get_json()
 
     assert response.status_code == 200
-    assert (await response.get_json())['data'] == {
+    assert payload['data'] == {
         'credits': 25000,
         'owner_space_bound': True,
         'is_workspace_owner': True,
     }
     application.space_service.get_credits.assert_awaited_once_with('owner@example.com')
+
+
+@pytest.mark.asyncio
+async def test_cloud_workspace_owner_is_always_space_bound_after_login(space_oauth_api):
+    application, client = space_oauth_api
+    application.deployment.mode = 'cloud'
+    application.user_service.get_workspace_owner = AsyncMock(return_value=None)
+    application.space_service.get_credits = AsyncMock()
+
+    response = await client.get(
+        '/api/v1/user/space-credits',
+        headers={'Authorization': 'Bearer account-token', 'X-Workspace-Id': WORKSPACE_UUID},
+    )
+    payload = await response.get_json()
+
+    assert response.status_code == 200
+    assert payload['data'] == {
+        'credits': None,
+        'owner_space_bound': True,
+        'is_workspace_owner': True,
+    }
+    application.space_service.get_credits.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What\n- treat every authenticated Cloud Workspace owner as already bound to LangBot Account\n- keep local OAuth-token lookup only for optional credits display\n- prevent the misleading owner-must-bind prompt when the projected owner row is unavailable locally\n\n## Why\nCloud login is issued by LangBot Account. A user cannot enter cloud.langbot.app without that account relationship, and model billing already uses the fixed Owner API key from the control plane.\n\n## Verification\n- RED regression reproduced before implementation\n- 98 targeted account/Workspace tests passed\n- 13 Space OAuth/API integration tests passed after final edit\n- Ruff check and format passed\n