### PR TITLE
fix(cloud): restore plugins and pipeline execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     "chromadb>=1.0.0,<2.0.0",
     "qdrant-client (>=1.15.1,<2.0.0)",
     "pyseekdb==1.1.0.post3",
-    "langbot-plugin @ git+https://github.com/langbot-app/langbot-plugin-sdk.git@1d65ed301a6afc52150a998043f73cd6032c8162",
+    "langbot-plugin @ git+https://github.com/langbot-app/langbot-plugin-sdk.git@101e453e916b39465a6294d6471c9eaae8725d5c",
     "asyncpg>=0.30.0",
     "line-bot-sdk>=3.19.0",
     "matrix-nio>=0.25.2",

--- a/src/langbot/pkg/pipeline/controller.py
+++ b/src/langbot/pkg/pipeline/controller.py
@@ -132,9 +132,7 @@ class Controller:
 
                             break
 
-                    if selected_query:  # 找到了
-                        queries.remove(selected_query)
-                    else:  # 没找到 说明：没有请求 或者 所有query对应的session都已达到并发上限
+                    if not selected_query:  # 没找到 说明：没有请求 或者 所有query对应的session都已达到并发上限
                         await self.ap.query_pool.condition.wait()
                         continue
 

--- a/tests/unit_tests/pipeline/test_controller_tenancy.py
+++ b/tests/unit_tests/pipeline/test_controller_tenancy.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from langbot.pkg.persistence.mgr import PersistenceManager, PersistenceMode
 from langbot.pkg.persistence.tenant_uow import PersistenceScopeKind
 from langbot.pkg.pipeline.controller import Controller
+from langbot.pkg.pipeline.pool import QueryPool
 from langbot.pkg.workspace.errors import WorkspaceGenerationMismatchError
 
 
@@ -143,3 +144,31 @@ async def test_controller_revalidates_generation_before_running_pipeline(
     runtime_pipeline.run.assert_awaited_once_with(sample_query)
     query_pool.remove_query.assert_awaited_once_with(sample_query)
     session._semaphore.release.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_controller_schedules_query_without_removing_it_twice(mock_app, sample_query):
+    query_pool = QueryPool()
+    query_pool.queries.append(sample_query)
+    mock_app.query_pool = query_pool
+    mock_app.sess_mgr.get_session = AsyncMock(return_value=SimpleNamespace(_semaphore=asyncio.Semaphore(1)))
+
+    scheduler_errors: list[str] = []
+
+    def stop_on_scheduler_error(message):
+        scheduler_errors.append(str(message))
+        raise asyncio.CancelledError
+
+    def stop_after_scheduling(process_coro, **_kwargs):
+        process_coro.close()
+        raise asyncio.CancelledError
+
+    mock_app.logger.error.side_effect = stop_on_scheduler_error
+    mock_app.task_mgr.create_task.side_effect = stop_after_scheduling
+    controller = Controller(mock_app)
+
+    with pytest.raises(asyncio.CancelledError):
+        await controller.consumer()
+
+    assert scheduler_errors == []
+    assert query_pool.queries == []

--- a/uv.lock
+++ b/uv.lock
@@ -2116,7 +2116,7 @@ requires-dist = [
     { name = "ebooklib", specifier = ">=0.18" },
     { name = "gewechat-client", specifier = ">=0.1.5" },
     { name = "html2text", specifier = ">=2024.2.26" },
-    { name = "langbot-plugin", git = "https://github.com/langbot-app/langbot-plugin-sdk.git?rev=1d65ed301a6afc52150a998043f73cd6032c8162" },
+    { name = "langbot-plugin", git = "https://github.com/langbot-app/langbot-plugin-sdk.git?rev=101e453e916b39465a6294d6471c9eaae8725d5c" },
     { name = "langchain", specifier = ">=1.3.9" },
     { name = "langchain-core", specifier = ">=1.3.3" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
@@ -2182,8 +2182,8 @@ dev = [
 
 [[package]]
 name = "langbot-plugin"
-version = "0.4.18"
-source = { git = "https://github.com/langbot-app/langbot-plugin-sdk.git?rev=1d65ed301a6afc52150a998043f73cd6032c8162#1d65ed301a6afc52150a998043f73cd6032c8162" }
+version = "0.5.0"
+source = { git = "https://github.com/langbot-app/langbot-plugin-sdk.git?rev=101e453e916b39465a6294d6471c9eaae8725d5c#101e453e916b39465a6294d6471c9eaae8725d5c" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- remove the duplicate pipeline queue deletion that crashes every debug/live query before model invocation
- bump Plugin SDK from 0.4.18 to 0.5.0 so shared workers import the trusted Runtime SDK before plugin dependencies
- add a regression test for the pipeline scheduling path

## Production evidence
- Pipeline Debug Chat reproducibly fails at controller.py with `ValueError: list.remove(x): x not in list`
- Marketplace worker imports plugin dependency SDK 0.4.17 because production sets `PYTHONPATH=/plugin-dependencies`; instrumented nsjail execution fails during handler initialization and never registers
- SDK 0.5.0 constructs `<runtime site-packages>:/plugin-dependencies`, preserving trusted shared-worker protocol and writable storage behavior

## Verification
- `179 passed` across pipeline, plugin API/security, and plugin unit tests
- SDK worker launcher tests: `15 passed`
- Ruff: `All checks passed!`
- `uv lock --check` and `uv sync --locked`
