### PR TITLE
fix(cloud): preserve pipeline routing in debug chat

### DIFF
--- a/src/langbot/pkg/platform/sources/websocket_adapter.py
+++ b/src/langbot/pkg/platform/sources/websocket_adapter.py
@@ -707,28 +707,37 @@ class WebSocketAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter)
             if len(listener_tasks) >= 100:
                 await self.logger.warning('WebSocket inbound listener capacity reached; dropping message')
                 return
-            token = _current_pipeline_uuid.set(pipeline_uuid)
-            try:
-                task_manager = getattr(self.ap, 'task_mgr', None)
-                if task_manager is None or not isinstance(getattr(task_manager, 'tasks', None), list):
-                    listener_task = asyncio.create_task(listeners[event.__class__](event, callback_adapter))
-                else:
-                    listener_task = task_manager.create_task(
-                        listeners[event.__class__](event, callback_adapter),
-                        kind='websocket-message',
-                        name=f'websocket-message-{connection.connection_id}',
-                        scopes=[
-                            core_entities.LifecycleControlScope.APPLICATION,
-                            core_entities.LifecycleControlScope.PLATFORM,
-                        ],
-                        instance_uuid=connection.instance_uuid,
-                        workspace_uuid=connection.workspace_uuid,
-                        placement_generation=connection.placement_generation,
-                    ).task
-                listener_tasks.add(listener_task)
-                listener_task.add_done_callback(self._listener_task_done)
-            finally:
-                _current_pipeline_uuid.reset(token)
+            listener = typing.cast(
+                typing.Callable[[typing.Any, typing.Any], typing.Awaitable[None]],
+                listeners[event.__class__],
+            )
+
+            async def run_listener():
+                token = _current_pipeline_uuid.set(pipeline_uuid)
+                try:
+                    await listener(event, callback_adapter)
+                finally:
+                    _current_pipeline_uuid.reset(token)
+
+            listener_coro = run_listener()
+            task_manager = getattr(self.ap, 'task_mgr', None)
+            if task_manager is None or not isinstance(getattr(task_manager, 'tasks', None), list):
+                listener_task = asyncio.create_task(listener_coro)
+            else:
+                listener_task = task_manager.create_task(
+                    listener_coro,
+                    kind='websocket-message',
+                    name=f'websocket-message-{connection.connection_id}',
+                    scopes=[
+                        core_entities.LifecycleControlScope.APPLICATION,
+                        core_entities.LifecycleControlScope.PLATFORM,
+                    ],
+                    instance_uuid=connection.instance_uuid,
+                    workspace_uuid=connection.workspace_uuid,
+                    placement_generation=connection.placement_generation,
+                ).task
+            listener_tasks.add(listener_task)
+            listener_task.add_done_callback(self._listener_task_done)
 
     def get_websocket_messages(
         self,

--- a/tests/unit_tests/platform/test_websocket_session_isolation.py
+++ b/tests/unit_tests/platform/test_websocket_session_isolation.py
@@ -1,6 +1,7 @@
 """Regression tests for isolated embed-widget conversations."""
 
 import asyncio
+import contextvars
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
@@ -202,6 +203,48 @@ async def test_embed_event_uses_stable_session_launcher(monkeypatch):
     await asyncio.sleep(0)
 
     assert received[0].sender.id == f'websocket_pipeline-1:{session_id}'
+
+
+@pytest.mark.asyncio
+async def test_pipeline_override_survives_detached_listener_task(monkeypatch):
+    manager = WebSocketConnectionManager()
+    connection = await manager.add_connection(
+        websocket=Mock(),
+        scope=SCOPE_A,
+        pipeline_uuid='pipeline-1',
+        session_type='person',
+    )
+    monkeypatch.setattr(websocket_adapter_module, 'ws_connection_manager', manager)
+
+    class DetachedTaskManager:
+        def __init__(self):
+            self.tasks = []
+
+        def create_task(self, coro, **_kwargs):
+            task = asyncio.create_task(coro, context=contextvars.Context())
+            self.tasks.append(task)
+            return Mock(task=task)
+
+    task_manager = DetachedTaskManager()
+    adapter = WebSocketAdapter.model_construct(
+        ap=Mock(task_mgr=task_manager),
+        logger=_adapter_logger(),
+    )
+    adapter.websocket_person_session = WebSocketSession(id='person')
+    adapter.websocket_group_session = WebSocketSession(id='group')
+    pipeline_overrides = []
+
+    async def listener(_event, callback_adapter):
+        pipeline_overrides.append(callback_adapter.get_pipeline_uuid_override())
+
+    adapter.listeners = {platform_events.FriendMessage: listener}
+    await adapter.handle_websocket_message(
+        connection,
+        {'message': [{'type': 'Plain', 'text': 'hello'}], 'stream': False},
+    )
+    await asyncio.gather(*task_manager.tasks)
+
+    assert pipeline_overrides == ['pipeline-1']
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- set the dashboard pipeline override inside the listener coroutine itself
- preserve the override even when TaskManager intentionally creates a detached context
- add a regression test that reproduces the production detached-task behavior

## Production evidence
After the queue double-removal fix, Debug Chat reached the controller but dropped the query as `No pipeline_uuid for query 0`. The WebSocket adapter set a ContextVar around task creation, while `TaskWrapper` uses `create_detached_task`, which deliberately starts with a clean context.

## Verification
- 37 focused WebSocket, Pipeline API, and controller tests passed
- Ruff check and format passed
