### PR TITLE
fix(web): keep extension market navigable at quota

### DIFF
--- a/web/src/app/home/components/home-sidebar/HomeSidebar.tsx
+++ b/web/src/app/home/components/home-sidebar/HomeSidebar.tsx
@@ -543,33 +543,19 @@ function NavItems({
           if (config.id === 'add-extension' && !canManageResources) {
             return null;
           }
-          const quota =
-            config.id === 'add-extension'
-              ? quotaStatus.extensions
-              : UNLIMITED_QUOTA;
           // Non-entity entries (e.g. monitoring and the extension market) render as plain links.
           return (
             <SidebarMenuItem key={config.id}>
-              <WorkspaceQuotaTooltip
-                quota={quota}
-                resource={config.name}
-                side="right"
+              <SidebarMenuButton
+                isActive={selectedChild?.id === config.id}
+                onClick={() => onChildClick(config)}
+                tooltip={config.name}
               >
-                <SidebarMenuButton
-                  isActive={selectedChild?.id === config.id}
-                  onClick={() => {
-                    if (!quota.disabled) onChildClick(config);
-                  }}
-                  disabled={quota.disabled}
-                  aria-disabled={quota.disabled}
-                  tooltip={quota.disabled ? undefined : config.name}
-                >
-                  {config.icon}
-                  <span className="cursor-pointer select-none">
-                    {config.name}
-                  </span>
-                </SidebarMenuButton>
-              </WorkspaceQuotaTooltip>
+                {config.icon}
+                <span className="cursor-pointer select-none">
+                  {config.name}
+                </span>
+              </SidebarMenuButton>
             </SidebarMenuItem>
           );
         }

--- a/web/src/app/home/components/workspace-quota/WorkspaceQuotaTooltip.tsx
+++ b/web/src/app/home/components/workspace-quota/WorkspaceQuotaTooltip.tsx
@@ -39,7 +39,7 @@ export function WorkspaceQuotaTooltip({
           {children}
         </span>
       </TooltipTrigger>
-      <TooltipContent side={side} className="max-w-72 text-center">
+      <TooltipContent side={side} className="max-w-72 text-left">
         {message}
       </TooltipContent>
     </Tooltip>

--- a/web/src/app/home/plugins/components/plugin-market/plugin-market-card/PluginMarketCardComponent.tsx
+++ b/web/src/app/home/plugins/components/plugin-market/plugin-market-card/PluginMarketCardComponent.tsx
@@ -399,7 +399,7 @@ export default function PluginMarketCardComponent({
     <TooltipProvider delayDuration={200}>
       <Tooltip>
         <TooltipTrigger asChild>{cardContent}</TooltipTrigger>
-        <TooltipContent side="top" className="max-w-72 text-center">
+        <TooltipContent side="top" className="max-w-72 text-left">
           {installDisabledTooltip}
         </TooltipContent>
       </Tooltip>

--- a/web/tests/e2e/quota-create-actions.spec.ts
+++ b/web/tests/e2e/quota-create-actions.spec.ts
@@ -119,7 +119,7 @@ test('quota-reached create actions are disabled and explain the current limit', 
   await expect(botCreate).toBeDisabled();
   await expect(pipelineCreate).toBeDisabled();
   await expect(knowledgeCreate).toBeDisabled();
-  await expect(addExtension).toBeDisabled();
+  await expect(addExtension).toBeEnabled();
 
   const botQuotaTrigger = botCreate.locator('..');
   await botQuotaTrigger.hover();
@@ -136,7 +136,8 @@ test('quota-reached create actions are disabled and explain the current limit', 
     ),
   ).toBeVisible();
 
-  await page.goto('/home/add-extension');
+  await addExtension.click();
+  await expect(page).toHaveURL(/\/home\/add-extension$/);
   const manualAdd = page.getByRole('button', { name: 'Manual Add' });
   await expect(manualAdd).toBeDisabled();
   await manualAdd.locator('..').hover();

--- a/web/tests/unit/quota-create-actions.test.mjs
+++ b/web/tests/unit/quota-create-actions.test.mjs
@@ -63,7 +63,13 @@ test('sidebar quota-disables create controls and renders a tooltip', () => {
   assert.match(tooltip, /limitation\.createDisabledTooltip/);
   assert.match(tooltip, /limitation\.quotaLoadingTooltip/);
   assert.match(tooltip, /tabIndex=\{0\}/);
+  assert.match(tooltip, /max-w-72 text-left/);
+  assert.doesNotMatch(tooltip, /text-center/);
   assert.match(source, /config\.id === 'add-extension'/);
+  assert.doesNotMatch(
+    source,
+    /config\.id === 'add-extension'\s*\?\s*quotaStatus\.extensions/,
+  );
 });
 
 test('add-extension page disables all install entry points at the quota', () => {
@@ -80,6 +86,8 @@ test('add-extension page disables all install entry points at the quota', () => 
   assert.match(card, /installDisabled/);
   assert.match(card, /disabled=\{installDisabled\}/);
   assert.match(card, /TooltipContent/);
+  assert.match(card, /max-w-72 text-left/);
+  assert.doesNotMatch(card, /max-w-72 text-center/);
   assert.match(recommendations, /installDisabled=\{installDisabled\}/);
   assert.match(
     recommendations,


### PR DESCRIPTION
## Summary
- keep the Sidebar **Add Extension** entry enabled and navigable after the Workspace reaches its extension quota
- continue disabling install/create controls inside the Add Extension page
- left-align multi-line quota tooltip copy for easier reading

## Verification
- `node --test tests/unit/quota-create-actions.test.mjs` — 5/5 passed
- `pnpm exec playwright test tests/e2e/quota-create-actions.spec.ts --project=chromium --workers=1` — passed
- `pnpm run build` — passed
- changed-file ESLint — 0 errors (2 existing hook dependency warnings)
- real Chromium screenshot visually checked for left alignment and enabled Add Extension navigation
