### PR TITLE
fix(web): use natural tooltip wrapping

### DIFF
--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -119,7 +119,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
+          'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs',
           className,
         )}
         {...props}

--- a/web/tests/unit/quota-create-actions.test.mjs
+++ b/web/tests/unit/quota-create-actions.test.mjs
@@ -16,6 +16,7 @@ const tooltipPath = path.join(
   root,
   'src/app/home/components/workspace-quota/WorkspaceQuotaTooltip.tsx',
 );
+const baseTooltipPath = path.join(root, 'src/components/ui/tooltip.tsx');
 const addExtensionPath = path.join(root, 'src/app/home/add-extension/page.tsx');
 const marketPath = path.join(
   root,
@@ -55,6 +56,7 @@ test('workspace quota hook exposes reached states for every creatable resource',
 test('sidebar quota-disables create controls and renders a tooltip', () => {
   const source = fs.readFileSync(sidebarPath, 'utf8');
   const tooltip = fs.readFileSync(tooltipPath, 'utf8');
+  const baseTooltip = fs.readFileSync(baseTooltipPath, 'utf8');
   assert.match(source, /useWorkspaceQuotaStatus/);
   assert.match(source, /quota\.disabled/);
   assert.match(source, /disabled=\{quota\.disabled\}/);
@@ -65,6 +67,7 @@ test('sidebar quota-disables create controls and renders a tooltip', () => {
   assert.match(tooltip, /tabIndex=\{0\}/);
   assert.match(tooltip, /max-w-72 text-left/);
   assert.doesNotMatch(tooltip, /text-center/);
+  assert.doesNotMatch(baseTooltip, /text-balance/);
   assert.match(source, /config\.id === 'add-extension'/);
   assert.doesNotMatch(
     source,


### PR DESCRIPTION
## Summary
- remove the shared `text-balance` default from tooltip content
- restore normal greedy line wrapping so non-final lines use the available width
- retain quota tooltip max-width, left alignment, and viewport collision handling

## Root cause
`text-balance` intentionally made every line similar in length. On narrow mobile viewports this left a large empty area on the right of each line even though the tooltip itself was at its max width.

## Verification
- Node quota unit tests: 5/5 passed
- Focused Chromium quota E2E: passed
- Production web build: passed
- Changed-file ESLint: passed
- 402px CSS viewport / DPR 3 real Chromium screenshot verified natural wrapping and viewport containment
