### PR TITLE
chore: pin fenced plugin debug sessions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     "chromadb>=1.0.0,<2.0.0",
     "qdrant-client (>=1.15.1,<2.0.0)",
     "pyseekdb==1.1.0.post3",
-    "langbot-plugin @ git+https://github.com/langbot-app/langbot-plugin-sdk.git@22e470d853e00116ad4fa63d3171f88646b06153",
+    "langbot-plugin @ git+https://github.com/langbot-app/langbot-plugin-sdk.git@5279f3ebd8ca8ddfca27558d56c5900f2e245361",
     "asyncpg>=0.30.0",
     "line-bot-sdk>=3.19.0",
     "matrix-nio>=0.25.2",

--- a/uv.lock
+++ b/uv.lock
@@ -2125,7 +2125,7 @@ requires-dist = [
     { name = "ebooklib", specifier = ">=0.18" },
     { name = "gewechat-client", specifier = ">=0.1.5" },
     { name = "html2text", specifier = ">=2024.2.26" },
-    { name = "langbot-plugin", git = "https://github.com/langbot-app/langbot-plugin-sdk.git?rev=22e470d853e00116ad4fa63d3171f88646b06153" },
+    { name = "langbot-plugin", git = "https://github.com/langbot-app/langbot-plugin-sdk.git?rev=5279f3ebd8ca8ddfca27558d56c5900f2e245361" },
     { name = "langchain", specifier = ">=1.3.9" },
     { name = "langchain-core", specifier = ">=1.3.3" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
@@ -2192,7 +2192,7 @@ dev = [
 [[package]]
 name = "langbot-plugin"
 version = "0.5.0"
-source = { git = "https://github.com/langbot-app/langbot-plugin-sdk.git?rev=22e470d853e00116ad4fa63d3171f88646b06153#22e470d853e00116ad4fa63d3171f88646b06153" }
+source = { git = "https://github.com/langbot-app/langbot-plugin-sdk.git?rev=5279f3ebd8ca8ddfca27558d56c5900f2e245361#5279f3ebd8ca8ddfca27558d56c5900f2e245361" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },


### PR DESCRIPTION
Pin Plugin SDK 5279f3ebd8ca8ddfca27558d56c5900f2e245361, which closes the final post-merge security findings: tokenless control is loopback-only unless explicitly trusted, and established Workspace debug sessions are revalidated after expiry/rotation/fencing.\n\nVerification: Core plugin/API suite (170 passed); SDK CI and full suite (1124 passed).