### PR TITLE
fix(line): use stable source id for session identity

### DIFF
--- a/src/langbot/pkg/platform/sources/line.py
+++ b/src/langbot/pkg/platform/sources/line.py
@@ -101,7 +101,7 @@ class LINEEventConverter(abstract_platform_adapter.AbstractEventConverter):
         if event.source.type == 'user':
             return platform_events.FriendMessage(
                 sender=platform_entities.Friend(
-                    id=event.message.id,
+                    id=event.source.user_id,
                     nickname=event.source.user_id,
                     remark='',
                 ),
@@ -110,13 +110,19 @@ class LINEEventConverter(abstract_platform_adapter.AbstractEventConverter):
                 source_platform_object=event,
             )
         else:
+            # 'group' and 'room' sources carry the stable chat id under different
+            # field names; user_id may be absent for some members, so fall back
+            # to the group/room id rather than the per-message id.
+            group_id = event.source.group_id if event.source.type == 'group' else event.source.room_id
+            member_id = event.source.user_id or group_id
+
             return platform_events.GroupMessage(
                 sender=platform_entities.GroupMember(
-                    id=event.event.sender.sender_id.open_id,
-                    member_name=event.event.sender.sender_id.union_id,
+                    id=member_id,
+                    member_name=member_id,
                     permission=platform_entities.Permission.Member,
                     group=platform_entities.Group(
-                        id=event.message.id,
+                        id=group_id,
                         name='',
                         permission=platform_entities.Permission.Member,
                     ),

--- a/tests/unit_tests/platform/test_line_session_identity.py
+++ b/tests/unit_tests/platform/test_line_session_identity.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+
+from linebot.v3.webhooks import TextMessageContent
+
+from langbot.pkg.platform import botmgr as _botmgr  # noqa: F401
+from langbot.pkg.platform.sources import line
+
+
+def _make_event(*, source_type: str, user_id, group_id=None, room_id=None, message_id: str, text: str = 'hi'):
+    event = MagicMock()
+    event.timestamp = 1700000000000
+    event.message = MagicMock(spec=TextMessageContent)
+    event.message.id = message_id
+    event.message.text = text
+    event.message.webhook_event_id = f'webhook-{message_id}'
+    event.message.timestamp = event.timestamp
+
+    source = MagicMock()
+    source.type = source_type
+    source.user_id = user_id
+    if group_id is not None:
+        source.group_id = group_id
+    if room_id is not None:
+        source.room_id = room_id
+    event.source = source
+
+    return event
+
+
+@pytest.mark.asyncio
+async def test_user_message_launcher_id_stable_across_messages() -> None:
+    """Two distinct messages from the same LINE user must resolve to the same
+    sender id, otherwise every message starts a brand new session (context loss).
+    """
+    event1 = _make_event(source_type='user', user_id='U-stable-user', message_id='msg-1')
+    event2 = _make_event(source_type='user', user_id='U-stable-user', message_id='msg-2')
+
+    result1 = await line.LINEEventConverter.target2yiri(event1, bot_client=None)
+    result2 = await line.LINEEventConverter.target2yiri(event2, bot_client=None)
+
+    assert result1.sender.id == 'U-stable-user'
+    assert result1.sender.id == result2.sender.id
+    assert result1.sender.id != event1.message.id
+
+
+@pytest.mark.asyncio
+async def test_group_message_uses_group_id_not_message_id() -> None:
+    event1 = _make_event(source_type='group', user_id='U-member', group_id='G-stable-group', message_id='msg-1')
+    event2 = _make_event(source_type='group', user_id='U-member', group_id='G-stable-group', message_id='msg-2')
+
+    result1 = await line.LINEEventConverter.target2yiri(event1, bot_client=None)
+    result2 = await line.LINEEventConverter.target2yiri(event2, bot_client=None)
+
+    assert result1.sender.group.id == 'G-stable-group'
+    assert result1.sender.group.id == result2.sender.group.id
+    assert result1.sender.id == 'U-member'
+
+
+@pytest.mark.asyncio
+async def test_room_message_uses_room_id_and_falls_back_when_user_id_missing() -> None:
+    event = _make_event(source_type='room', user_id=None, room_id='R-stable-room', message_id='msg-1')
+
+    result = await line.LINEEventConverter.target2yiri(event, bot_client=None)
+
+    assert result.sender.group.id == 'R-stable-room'
+    assert result.sender.id == 'R-stable-room'


### PR DESCRIPTION
## Summary
- `LINEEventConverter.target2yiri()` built `Friend.id`/`Group.id` (and the `GroupMember` sender id) from `event.message.id`, which is unique per message — every incoming message therefore mapped to a different session key, so LINE users and groups lost conversation context on every single turn.
- Switched to `event.source.user_id`/`.group_id`/`.room_id`, the stable identifiers LINE actually provides for this purpose, matching the pattern already used by other adapters (e.g. `telegram.py` uses `event.effective_chat.id`).
- Falls back to the group/room id when `user_id` is absent, per LINE's documented behavior ("Only included in message events. Only users of LINE for iOS and LINE for Android are included in userId") for some group/room members.

## Test plan
- [x] Added `tests/unit_tests/platform/test_line_session_identity.py` covering: stable sender id across multiple messages from the same user, stable group id across multiple messages, and room-type fallback when `user_id` is missing.
- [x] `uv run pytest tests/unit_tests/platform/test_line_session_identity.py tests/unit_tests/platform/test_line_limits.py -q` — 6 passed
- [x] `uv run ruff check` / `ruff format --check` on changed files