### PR TITLE
feat(provider): add OrcaRouter provider

### DIFF
--- a/src/langbot/pkg/provider/modelmgr/requesters/orcarouter.svg
+++ b/src/langbot/pkg/provider/modelmgr/requesters/orcarouter.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="5" cy="5" r="2.5" fill="#0E7C86"/>
+<circle cx="5" cy="19" r="2.5" fill="#0E7C86"/>
+<circle cx="19" cy="5" r="2.5" fill="#0E7C86"/>
+<circle cx="19" cy="19" r="2.5" fill="#0E7C86"/>
+<circle cx="12" cy="12" r="3" fill="#0E7C86"/>
+<path d="M6.5 6.5L10 10" stroke="#0E7C86" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M6.5 17.5L10 14" stroke="#0E7C86" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M17.5 6.5L14 10" stroke="#0E7C86" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M17.5 17.5L14 14" stroke="#0E7C86" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/src/langbot/pkg/provider/modelmgr/requesters/orcarouterchatcmpl.yaml
+++ b/src/langbot/pkg/provider/modelmgr/requesters/orcarouterchatcmpl.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: LLMAPIRequester
+metadata:
+  name: orcarouter-chat-completions
+  label:
+    en_US: OrcaRouter
+    zh_Hans: OrcaRouter
+  icon: orcarouter.svg
+spec:
+  litellm_provider: openai
+  config:
+  - name: base_url
+    label:
+      en_US: Base URL
+      zh_Hans: 基础 URL
+    type: string
+    required: true
+    default: https://api.orcarouter.ai/v1
+  - name: timeout
+    label:
+      en_US: Timeout
+      zh_Hans: 超时时间
+    type: integer
+    required: true
+    default: 120
+  alias: "orcarouter OrcaRouter orca router 网关 聚合 路由 openai anthropic claude gpt gemini deepseek qwen"
+  support_type:
+  - llm
+  provider_category: maas
+execution:
+  python:
+    path: ./orcarouterchatcmpl.py
+    attr: OrcaRouterChatCompletions


### PR DESCRIPTION
## Overview

Adds [OrcaRouter](https://www.orcarouter.ai) as a named provider in the Manager's provider picker, mirroring the existing OpenRouter and Moonshot/Chat Completions presets. OrcaRouter is an OpenAI-compatible model routing gateway that exposes models from OpenAI, Anthropic, Google, DeepSeek, Qwen and others behind a single endpoint and API key, using namespaced model IDs such as `openai/gpt-5.5` and `orcarouter/fusion`. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The provider is wired through the existing declarative `LLMAPIRequester` discovery mechanism: a new manifest (`orcarouterchatcmpl.yaml`) plus an icon is all it takes — the model manager auto-registers it via `litellm_provider: openai` with the base URL `https://api.orcarouter.ai/v1`, and it appears in the provider list without any Python changes.

### Files changed

- `src/langbot/pkg/provider/modelmgr/requesters/orcarouterchatcmpl.yaml` — new provider manifest (mirrors `openrouterchatcmpl.yaml` / `moonshotcnchatcmpl.yaml` shape)
- `src/langbot/pkg/provider/modelmgr/requesters/orcarouter.svg` — provider icon

### How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. Add a model entry with the **OrcaRouter** requester, base URL `https://api.orcarouter.ai/v1`, and a namespaced model ID such as `orcarouter/fusion-mini` or `openai/gpt-5.5`.
3. OrcaRouter rejects bare model names (they return `503 No available channel`), so the model ID must carry its provider namespace.

### Verification

- New manifest parsed successfully against the existing `LLMAPIRequester` schema (structure identical to the merged `moonshotcnchatcmpl.yaml` precedent).
- Live API check through the same LiteLLM path the manager uses (`custom_llm_provider=openai`, base URL `https://api.orcarouter.ai/v1`, `sk-orca-` key):
  - `orcarouter/fusion-mini` → HTTP 200, tool calls returned ✅
  - `orcarouter/fusion` → HTTP 200, tool calls returned ✅
  - `orcarouter/auto` → HTTP 200, tool calls returned ✅
- No Python code is changed, so the existing unit test suite is unaffected.

## 检查清单 / Checklist

### PR 作者完成 / For PR author

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [x] 我已签署或将在机器人提示后签署 [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。 / I have signed, or will sign when prompted by the bot, the [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md).
- [ ] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

I'm an engineer on the OrcaRouter team.
