### PR TITLE
fix(deps): constrain mcp to v1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pynacl>=1.5.0", # Required for Discord voice support
     "gewechat-client>=0.1.5",
     "lark-oapi>=1.5.5",
-    "mcp>=1.25.0",
+    "mcp>=1.25.0,<2.0.0",
     "nakuru-project-idk>=0.0.2.1",
     "ollama>=0.4.8",
     "openai>1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2136,7 +2136,7 @@ requires-dist = [
     { name = "mako", specifier = ">=1.3.12" },
     { name = "markdown", specifier = ">=3.6" },
     { name = "matrix-nio", specifier = ">=0.25.2" },
-    { name = "mcp", specifier = ">=1.25.0" },
+    { name = "mcp", specifier = ">=1.25.0,<2.0.0" },
     { name = "mypy", specifier = ">=1.16.0" },
     { name = "nakuru-project-idk", specifier = ">=0.0.2.1" },
     { name = "ollama", specifier = ">=0.4.8" },


### PR DESCRIPTION
## Summary
- constrain the MCP Python SDK to `>=1.25.0,<2.0.0`
- keep the lockfile metadata aligned with the project dependency
- prevent `uvx langbot@latest` from resolving MCP 2.x, which removed `mcp.server.fastmcp`

## Verification
- `uv lock --check`
- `uv run python -c 'from mcp.server.fastmcp import FastMCP; import importlib.metadata as m; print(m.version("mcp"), FastMCP.__name__)'` → `1.26.0 FastMCP`\n\nCloses #2412