### PR TITLE
fix(deploy): preserve recovered Cloud adapter pin

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   CORE_IMAGE: ${{ secrets.DOCKER_USERNAME }}/langbot
   CLOUD_IMAGE: ${{ secrets.DOCKER_USERNAME }}/langbot-cloud-core
-  SPACE_REF: 58253c53933f95d81b035fbe2efedb55b6c1a82b
+  SPACE_REF: 1c31172dee7aa912ce807d899018de27ff29054f
 
 jobs:
   build-and-deploy:

--- a/tests/unit_tests/cloud/test_deploy_prod_config.py
+++ b/tests/unit_tests/cloud/test_deploy_prod_config.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_RECOVERY_SPACE_REF = '1c31172dee7aa912ce807d899018de27ff29054f'
+
+
+def test_production_build_pins_recovered_cloud_adapter_revision():
+    workflow = (_REPO_ROOT / '.github' / 'workflows' / 'deploy-prod.yml').read_text(encoding='utf-8')
+
+    assert f'SPACE_REF: {_RECOVERY_SPACE_REF}' in workflow


### PR DESCRIPTION
## Summary
- carry the production-only recovered Space Cloud adapter revision onto master
- add a regression test so master and deploy/prod can remain identical without silently regressing the Cloud control-plane retry/concurrency recovery

## Compatibility audit
- production-only Cloud fixes #2382, #2384, and #2387 are patch-identical to their master re-landings
- knowledge indexing, 3072-dimensional retrieval, and post-activation model provisioning are present on master
- master pins langbot-plugin 0.5.1, which contains the prior production SDK revision plus standalone-runtime compatibility
- OSS tokenless external runtimes and Cloud authenticated runtimes are covered by focused connector/deployment tests
- recovered Cloud adapter suite: 59 passed against current LangBot master

## Verification
- 111 focused LangBot tests passed
- frontend TypeScript and production build passed
- deploy workflow YAML parsed successfully
- Ruff and diff checks passed