### PR TITLE
feat(health): expose plugin runtime readiness

### DIFF
--- a/src/langbot/pkg/core/app.py
+++ b/src/langbot/pkg/core/app.py
@@ -249,6 +249,10 @@ class Application:
                     {},
                 )
             ),
+            'plugin_runtime_connected': bool(
+                self.plugin_connector is not None
+                and getattr(self.plugin_connector, '_runtime_available', lambda: False)()
+            ),
         }
         mcp_loader = getattr(self.tool_mgr, 'mcp_tool_loader', None)
         runtime_stats.update(

--- a/tests/unit_tests/core/test_app_shutdown.py
+++ b/tests/unit_tests/core/test_app_shutdown.py
@@ -87,7 +87,10 @@ async def test_runtime_resource_stats_are_aggregate_and_constant_time() -> None:
     app.platform_mgr = SimpleNamespace(_bots_by_key={})
     app.pipeline_mgr = SimpleNamespace(_pipelines_by_key={})
     app.rag_mgr = SimpleNamespace(knowledge_bases={})
-    app.plugin_connector = SimpleNamespace(_known_desired_states={'installation': object()})
+    app.plugin_connector = SimpleNamespace(
+        _known_desired_states={'installation': object()},
+        _runtime_available=lambda: True,
+    )
     app.persistence_mgr = SimpleNamespace(
         get_resource_stats=lambda: {
             'configured_capacity': 20,
@@ -140,3 +143,4 @@ async def test_runtime_resource_stats_are_aggregate_and_constant_time() -> None:
     }
     assert stats['models']['providers'] == 1
     assert stats['runtimes']['plugin_installations'] == 1
+    assert stats['runtimes']['plugin_runtime_connected'] is True


### PR DESCRIPTION
## Summary
- expose authoritative Plugin Runtime connection readiness in `/healthz`
- distinguish a running runtime process from a completed shared reconcile
- add resource telemetry regression coverage

Cloud production will consume this field in its container healthcheck so a deployment cannot be accepted while Plugin Runtime is disconnected.

## Verification
- focused Core resource tests passed
- Ruff and diff checks passed