### PR TITLE
docs(deploy): document optional runtime tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ cd LangBot/docker
 docker compose --profile all up -d
 ```
 
+> If the deployment is accessible from the Internet, protect the internal Runtime connections with strong tokens:
+>
+> ```bash
+> export LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN="$(openssl rand -hex 32)"
+> export LANGBOT_BOX_CONTROL_TOKEN="$(openssl rand -hex 32)"
+> docker compose --profile all up -d
+> ```
+>
+> Compose passes each value to both ends of its connection. If both ends leave a token unset, the open-source deployment permits a tokenless connection for backward compatibility. Store configured values in your deployment secret manager; do not commit them.
+
 ### One-Click Cloud Deploy
 
 [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/en-US/templates/ZKTBDH)

--- a/README_CN.md
+++ b/README_CN.md
@@ -83,6 +83,16 @@ cd LangBot/docker
 docker compose --profile all up -d
 ```
 
+> 如果部署环境可从公网访问，建议为内部 Runtime 连接设置强 Token：
+>
+> ```bash
+> export LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN="$(openssl rand -hex 32)"
+> export LANGBOT_BOX_CONTROL_TOKEN="$(openssl rand -hex 32)"
+> docker compose --profile all up -d
+> ```
+>
+> Compose 会把每个 Token 传给对应连接的两端。开源版在两端都未设置 Token 时仍允许无 Token 连接，以保持向后兼容。已配置的 Token 应保存在部署平台的 Secret 管理中，不要提交到仓库。
+
 ### 一键云部署
 
 [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/zh-CN/templates/ZKTBDH)

--- a/README_ES.md
+++ b/README_ES.md
@@ -82,6 +82,8 @@ cd LangBot/docker
 docker compose --profile all up -d
 ```
 
+> Para despliegues accesibles desde Internet, recomendamos configurar `LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN` y `LANGBOT_BOX_CONTROL_TOKEN` con secretos compartidos robustos (al menos 32 caracteres que no sean espacios). Genera cada valor con `openssl rand -hex 32`; Compose lo proporciona a ambos extremos de la conexión correspondiente. Si ambos extremos dejan el Token sin configurar, la edición de código abierto permite la conexión sin Token por compatibilidad.
+
 ### Despliegue en la Nube con un Clic
 
 [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/en-US/templates/ZKTBDH)

--- a/README_FR.md
+++ b/README_FR.md
@@ -82,6 +82,8 @@ cd LangBot/docker
 docker compose --profile all up -d
 ```
 
+> Pour un déploiement accessible depuis Internet, nous recommandons de définir `LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN` et `LANGBOT_BOX_CONTROL_TOKEN` avec des secrets partagés robustes (au moins 32 caractères non blancs). Générez chaque valeur avec `openssl rand -hex 32` ; Compose la transmet aux deux extrémités de la connexion concernée. Si les deux extrémités ne définissent aucun Token, l’édition open source autorise la connexion sans Token pour assurer la compatibilité.
+
 ### Déploiement Cloud en un Clic
 
 [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/en-US/templates/ZKTBDH)

--- a/README_JP.md
+++ b/README_JP.md
@@ -82,6 +82,8 @@ cd LangBot/docker
 docker compose --profile all up -d
 ```
 
+> インターネットからアクセス可能な環境では、`LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN` と `LANGBOT_BOX_CONTROL_TOKEN` に強力な共有シークレット（空白以外の文字を32文字以上）を設定することを推奨します。各値は `openssl rand -hex 32` で生成でき、Compose が対応する接続の両端に同じ値を渡します。両端とも Token を未設定にした場合、オープンソース版では互換性のため Token なしの接続を許可します。
+
 ### ワンクリッククラウドデプロイ
 
 [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/en-US/templates/ZKTBDH)

--- a/README_KO.md
+++ b/README_KO.md
@@ -82,6 +82,8 @@ cd LangBot/docker
 docker compose --profile all up -d
 ```
 
+> 인터넷에서 접근 가능한 배포 환경에서는 `LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN`과 `LANGBOT_BOX_CONTROL_TOKEN`에 강력한 공유 시크릿(공백이 아닌 문자 32자 이상)을 설정하는 것을 권장합니다. 각 값은 `openssl rand -hex 32`로 생성할 수 있으며 Compose가 해당 연결의 양쪽에 동일한 값을 전달합니다. 양쪽 모두 Token을 설정하지 않으면 오픈 소스 버전은 호환성을 위해 Token 없는 연결을 허용합니다.
+
 ### 원클릭 클라우드 배포
 
 [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/en-US/templates/ZKTBDH)

--- a/README_RU.md
+++ b/README_RU.md
@@ -82,6 +82,8 @@ cd LangBot/docker
 docker compose --profile all up -d
 ```
 
+> Для развёртываний, доступных из Интернета, рекомендуем задать `LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN` и `LANGBOT_BOX_CONTROL_TOKEN` как надёжные общие секреты (не менее 32 непробельных символов). Каждое значение можно создать командой `openssl rand -hex 32`; Compose передаст его обеим сторонам соответствующего соединения. Если Token не задан с обеих сторон, версия с открытым исходным кодом разрешает соединение без Token для обратной совместимости.
+
 ### Облачное развертывание одним кликом
 
 [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/en-US/templates/ZKTBDH)

--- a/README_TW.md
+++ b/README_TW.md
@@ -84,6 +84,16 @@ cd LangBot/docker
 docker compose --profile all up -d
 ```
 
+> 如果部署環境可從公網存取，建議為內部 Runtime 連線設定強 Token：
+>
+> ```bash
+> export LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN="$(openssl rand -hex 32)"
+> export LANGBOT_BOX_CONTROL_TOKEN="$(openssl rand -hex 32)"
+> docker compose --profile all up -d
+> ```
+>
+> Compose 會將每個 Token 傳給對應連線的兩端。開源版在兩端都未設定 Token 時仍允許無 Token 連線，以保持向後相容。已設定的 Token 應儲存在部署平台的 Secret 管理中，不要提交至儲存庫。
+
 ### 一鍵雲端部署
 
 [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/zh-CN/templates/ZKTBDH)

--- a/README_VI.md
+++ b/README_VI.md
@@ -82,6 +82,8 @@ cd LangBot/docker
 docker compose --profile all up -d
 ```
 
+> Với triển khai có thể truy cập từ Internet, bạn nên đặt `LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN` và `LANGBOT_BOX_CONTROL_TOKEN` thành các khóa bí mật dùng chung đủ mạnh (ít nhất 32 ký tự không phải khoảng trắng). Có thể tạo từng giá trị bằng `openssl rand -hex 32`; Compose sẽ truyền cùng giá trị tới hai đầu của kết nối tương ứng. Nếu cả hai đầu đều không đặt Token, bản mã nguồn mở vẫn cho phép kết nối không Token để duy trì khả năng tương thích.
+
 ### Triển khai đám mây một cú nhấp
 
 [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/en-US/templates/ZKTBDH)

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -47,11 +47,10 @@ services:
     restart: on-failure
     environment:
       - TZ=Asia/Shanghai
-      # Shared control-plane secret used to authenticate both the RPC socket
-      # and managed-process relay. Generate once (for example with
-      # ``openssl rand -hex 32``) and export it before enabling this profile.
-      # An empty value is accepted by Compose so Box can remain optional, but
-      # the Box runtime itself fails closed when the profile is started.
+      # Optional shared control-plane secret used to authenticate both the RPC
+      # socket and managed-process relay. Leave unset on both OSS services, or
+      # generate one with ``openssl rand -hex 32`` and set the same value on
+      # both ends. Strongly recommended when the deployment is Internet-accessible.
       - LANGBOT_BOX_CONTROL_TOKEN=${LANGBOT_BOX_CONTROL_TOKEN:-}
       # Box has its own process-wide blocking-work budget.
       - LANGBOT_BLOCKING_EXECUTOR_MAX_WORKERS=${LANGBOT_BLOCKING_EXECUTOR_MAX_WORKERS:-8}
@@ -79,8 +78,9 @@ services:
       - TZ=Asia/Shanghai
       # Optional. Leave unset on both OSS services, or match plugin Runtime.
       - LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN=${LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN:-}
-      # Must match the value supplied to langbot_box. The token is sent only
-      # in WebSocket handshake headers, never in URLs or action payloads.
+      # When set, this must match langbot_box. If both ends leave it unset,
+      # OSS permits the connection without token authentication. The token is
+      # sent only in WebSocket handshake headers, never in URLs or payloads.
       - LANGBOT_BOX_CONTROL_TOKEN=${LANGBOT_BOX_CONTROL_TOKEN:-}
       # Core process-wide blocking-work admission. These are native config
       # overrides and are persisted with the effective data/config.yaml.


### PR DESCRIPTION
## Summary
- document optional Plugin Runtime and Box control tokens in all localized READMEs
- recommend strong tokens for Internet-accessible deployments
- clarify that OSS connections remain tokenless when both ends leave the token unset
- correct stale Box Compose comments that incorrectly claimed empty tokens fail closed

## Verification
- `docker compose -f docker/docker-compose.yaml config -q`
- all 9 localized READMEs include both token variables
- `git diff --check`
- local package build reports `Version: 4.10.7`