### PR TITLE
fix(web): restore plugin page SDK loading

### DIFF
--- a/web/src/app/infra/http/BackendClient.ts
+++ b/web/src/app/infra/http/BackendClient.ts
@@ -710,11 +710,32 @@ export class BackendClient extends BaseHttpClient {
     );
   }
 
-  private async getAuthenticatedObjectURL(path: string): Promise<string> {
+  private async getAuthenticatedObjectURL(
+    path: string,
+    rewritePluginPageSdk = false,
+  ): Promise<string> {
     const response = await this.instance.get<Blob>(path, {
       responseType: 'blob',
     });
-    return URL.createObjectURL(response.data);
+    let blob = response.data;
+    if (rewritePluginPageSdk && blob.type.startsWith('text/html')) {
+      const apiBase =
+        this.instance.defaults.baseURL === '/'
+          ? window.location.origin
+          : this.instance.defaults.baseURL?.replace(/\/$/, '');
+      const pageSdkUrl = `${apiBase}/api/v1/plugins/_sdk/page-sdk.js`;
+      const html = await blob.text();
+      blob = new Blob(
+        [
+          html.replace(
+            /(<script\b[^>]*\bsrc\s*=\s*)(["'])\/api\/v1\/plugins\/_sdk\/page-sdk\.js\2/gi,
+            `$1$2${pageSdkUrl}$2`,
+          ),
+        ],
+        { type: blob.type },
+      );
+    }
+    return URL.createObjectURL(blob);
   }
 
   public getAuthenticatedPluginAssetURL(
@@ -724,6 +745,7 @@ export class BackendClient extends BaseHttpClient {
   ): Promise<string> {
     return this.getAuthenticatedObjectURL(
       `/api/v1/plugins/${author}/${name}/authenticated-assets/${filepath}`,
+      true,
     );
   }
 

--- a/web/tests/e2e/plugin-page-auth.spec.ts
+++ b/web/tests/e2e/plugin-page-auth.spec.ts
@@ -69,7 +69,55 @@ test('loads a Cloud plugin page through the authenticated asset route', async ({
       await route.fulfill({
         status: 200,
         contentType: 'text/html',
-        body: '<!doctype html><html><body><h1>LangRAG Observability</h1></body></html>',
+        body: `<!doctype html>
+          <html>
+            <body>
+              <h1>LangRAG Observability</h1>
+              <button id="save">Save</button>
+              <script src="/api/v1/plugins/_sdk/page-sdk.js"></script>
+              <script>
+                document.querySelector('#save').addEventListener('click', async () => {
+                  await window.langbot.api('/settings', { enabled: true }, 'POST');
+                  document.body.dataset.saved = 'true';
+                });
+              </script>
+            </body>
+          </html>`,
+      });
+    },
+  );
+  let pageSdkRequests = 0;
+  await page.route('**/api/v1/plugins/_sdk/page-sdk.js', async (route) => {
+    pageSdkRequests += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      body: `window.langbot = {
+        api(endpoint, body, method) {
+          return new Promise((resolve) => {
+            const requestId = 'request-' + Date.now();
+            const handler = (event) => {
+              if (event.data?.type === 'langbot:api:response' && event.data.requestId === requestId) {
+                window.removeEventListener('message', handler);
+                resolve(event.data.data);
+              }
+            };
+            window.addEventListener('message', handler);
+            window.parent.postMessage({ type: 'langbot:api', requestId, endpoint, body, method }, '*');
+          });
+        },
+      };`,
+    });
+  });
+  let pageApiRequests = 0;
+  await page.route(
+    '**/api/v1/plugins/langbot-team/LangRAG/page-api',
+    async (route) => {
+      pageApiRequests += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: wrapped({ saved: true }),
       });
     },
   );
@@ -78,11 +126,17 @@ test('loads a Cloud plugin page through the authenticated asset route', async ({
     '/home/plugin-pages?id=langbot-team%2FLangRAG%2Fobservability',
   );
 
+  const pluginFrame = page.frameLocator('iframe');
   await expect(
-    page
-      .frameLocator('iframe')
-      .getByRole('heading', { name: 'LangRAG Observability' }),
+    pluginFrame.getByRole('heading', { name: 'LangRAG Observability' }),
   ).toBeVisible();
+  await pluginFrame.getByRole('button', { name: 'Save' }).click();
+  await expect(pluginFrame.locator('body')).toHaveAttribute(
+    'data-saved',
+    'true',
+  );
   expect(authenticatedAssetRequests).toBeGreaterThan(0);
+  expect(pageSdkRequests).toBe(1);
+  expect(pageApiRequests).toBe(1);
   await expect(page.getByText('Loading...')).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary

Fix plugin extension pages loaded through authenticated Blob URLs so the Page SDK resolves to the LangBot HTTP origin.

Closes #2434.

## Root cause

The workspace hardening change switched authenticated plugin pages from direct HTTP iframe URLs to fetched Blob URLs. A Blob document has no usable HTTP base URL, so the root-relative Page SDK reference (`/api/v1/plugins/_sdk/page-sdk.js`) did not load. As a result `window.langbot` was unavailable, button actions never posted `langbot:api` messages, and `/page-api` was never called.

## Fix

- Rewrite only the Page SDK script URL in authenticated HTML blobs to an absolute LangBot API URL.
- Preserve the Blob document base for plugin-relative resources and i18n paths.
- Leave non-HTML blobs and authenticated icons unchanged.
- Extend the Playwright regression test to verify SDK loading and a real Save -> `langbot:api` -> `/page-api` round trip.

## Verification

- Regression test fails against pre-fix `BackendClient.ts` and passes with the fix.
- `pnpm test:unit`: 34 passed.
- Targeted Playwright test: 1 passed.
- ESLint, Prettier, TypeScript/Vite build passed.
- Real v4.10.7 container + FAQManager: reproduced before the fix (Add left inputs unchanged, 0 `/page-api` requests); rebuilt frontend with the fix and verified Add clears inputs, creates the new FAQ row, and emits successful `/page-api` requests.
