### PR TITLE
test(migration): preserve legacy plugin storage payloads

### DIFF
--- a/tests/integration/persistence/resource_migration_support.py
+++ b/tests/integration/persistence/resource_migration_support.py
@@ -81,6 +81,7 @@ async def create_legacy_resource_schema(engine, *, instance_uuid: str) -> None:
         sa.Column('key', sa.String(255), nullable=False),
         sa.Column('owner_type', sa.String(255), nullable=False),
         sa.Column('owner', sa.String(255), nullable=False),
+        sa.Column('value', sa.LargeBinary, nullable=False),
     )
     mcp_servers = _uuid_table(
         metadata,
@@ -210,7 +211,13 @@ async def create_legacy_resource_schema(engine, *, instance_uuid: str) -> None:
         await conn.execute(bots.insert().values(uuid='bot-1', name='bot', updated_at=now))
         await conn.execute(bot_admins.insert().values(bot_uuid='bot-1', launcher_type='person', launcher_id='owner'))
         await conn.execute(
-            binary_storages.insert().values(unique_key='plugin:demo:key', key='key', owner_type='plugin', owner='demo')
+            binary_storages.insert().values(
+                unique_key='plugin:demo:key',
+                key='key',
+                owner_type='plugin',
+                owner='demo',
+                value=b'legacy-plugin-value',
+            )
         )
         await conn.execute(mcp_servers.insert().values(uuid='mcp-1', name='shared-name', enable=True, updated_at=now))
         await conn.execute(model_providers.insert().values(uuid='provider-1', name='provider', requester='openai'))

--- a/tests/integration/persistence/test_resource_tenancy_migration.py
+++ b/tests/integration/persistence/test_resource_tenancy_migration.py
@@ -76,6 +76,26 @@ async def test_legacy_sqlite_resources_are_backfilled_and_contracted(tmp_path):
             )
             assert legacy_kb['collection_id'] == 'collection-1'
             assert legacy_kb['legacy_vector_collection'] == 1
+            legacy_binary_storage = (
+                (
+                    await conn.execute(
+                        sa.text(
+                            'SELECT workspace_uuid, unique_key, key, owner_type, owner, value '
+                            "FROM binary_storages WHERE owner_type = 'plugin' AND owner = 'demo'"
+                        )
+                    )
+                )
+                .mappings()
+                .one()
+            )
+            assert legacy_binary_storage == {
+                'workspace_uuid': workspace_uuid,
+                'unique_key': 'plugin:demo:key',
+                'key': 'key',
+                'owner_type': 'plugin',
+                'owner': 'demo',
+                'value': b'legacy-plugin-value',
+            }
             assert (
                 await conn.scalar(
                     sa.text(
@@ -209,8 +229,8 @@ async def test_sqlite_scoped_keys_allow_cross_workspace_but_reject_same_workspac
             await conn.execute(
                 sa.text(
                     'INSERT INTO binary_storages '
-                    '(workspace_uuid, unique_key, key, owner_type, owner) '
-                    "VALUES (:workspace_uuid, 'plugin:demo:key', 'key', 'plugin', 'demo')"
+                    '(workspace_uuid, unique_key, key, owner_type, owner, value) '
+                    "VALUES (:workspace_uuid, 'plugin:demo:key', 'key', 'plugin', 'demo', X'')"
                 ),
                 {'workspace_uuid': second_workspace_uuid},
             )


### PR DESCRIPTION
## Summary
- add real legacy binary storage payload to the pre-tenancy schema fixture
- assert the migration keeps its Workspace assignment, key, owner and bytes unchanged

## Verification
- resource tenancy migration integration suite: 4 passed
- Ruff, format check and git diff --check pass