### PR TITLE
fix(plugin): keep pre-tenancy plugin storage readable

### DIFF
--- a/src/langbot/pkg/plugin/handler.py
+++ b/src/langbot/pkg/plugin/handler.py
@@ -431,6 +431,19 @@ class RuntimeConnectionHandler(handler.Handler):
             return f'{identity.plugin_author}/{identity.plugin_name}'
         raise ValueError(f'Unsupported binary storage owner_type {owner_type!r}')
 
+    @staticmethod
+    def _legacy_binary_storage_key(
+        action_context: ActionContext,
+        *,
+        owner_type: str,
+        owner: str,
+        key: str,
+    ) -> str:
+        """Return the pre-tenancy key shape for a row already scoped to this Workspace."""
+
+        legacy_owner = action_context.workspace_uuid if owner_type == 'workspace' else owner
+        return f'{owner_type}:{legacy_owner}:{key}'
+
     @classmethod
     def _binary_storage_key(
         cls,
@@ -896,8 +909,32 @@ class RuntimeConnectionHandler(handler.Handler):
                 .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
                 .where(persistence_bstorage.BinaryStorage.unique_key == unique_key)
             )
+            storage = result.first()
+            if storage is None:
+                legacy_key = self._legacy_binary_storage_key(
+                    action_context,
+                    owner_type=owner_type,
+                    owner=owner,
+                    key=key,
+                )
+                result = await self.ap.persistence_mgr.execute_async(
+                    sqlalchemy.select(persistence_bstorage.BinaryStorage)
+                    .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
+                    .where(persistence_bstorage.BinaryStorage.unique_key == legacy_key)
+                    .where(persistence_bstorage.BinaryStorage.key == key)
+                    .where(persistence_bstorage.BinaryStorage.owner_type == owner_type)
+                    .where(persistence_bstorage.BinaryStorage.owner == owner)
+                )
+                storage = result.first()
+                if storage is not None:
+                    await self.ap.persistence_mgr.execute_async(
+                        sqlalchemy.update(persistence_bstorage.BinaryStorage)
+                        .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
+                        .where(persistence_bstorage.BinaryStorage.unique_key == legacy_key)
+                        .values(unique_key=unique_key)
+                    )
 
-            if result.first() is not None:
+            if storage is not None:
                 await self.ap.persistence_mgr.execute_async(
                     sqlalchemy.update(persistence_bstorage.BinaryStorage)
                     .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
@@ -946,6 +983,29 @@ class RuntimeConnectionHandler(handler.Handler):
             )
 
             storage = result.first()
+            if storage is None:
+                legacy_key = self._legacy_binary_storage_key(
+                    action_context,
+                    owner_type=owner_type,
+                    owner=owner,
+                    key=key,
+                )
+                result = await self.ap.persistence_mgr.execute_async(
+                    sqlalchemy.select(persistence_bstorage.BinaryStorage)
+                    .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
+                    .where(persistence_bstorage.BinaryStorage.unique_key == legacy_key)
+                    .where(persistence_bstorage.BinaryStorage.key == key)
+                    .where(persistence_bstorage.BinaryStorage.owner_type == owner_type)
+                    .where(persistence_bstorage.BinaryStorage.owner == owner)
+                )
+                storage = result.first()
+                if storage is not None:
+                    await self.ap.persistence_mgr.execute_async(
+                        sqlalchemy.update(persistence_bstorage.BinaryStorage)
+                        .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
+                        .where(persistence_bstorage.BinaryStorage.unique_key == legacy_key)
+                        .values(unique_key=unique_key)
+                    )
             if storage is None:
                 return handler.ActionResponse.error(
                     message=f'Storage with key {key} not found',

--- a/tests/unit_tests/plugin/test_handler_actions.py
+++ b/tests/unit_tests/plugin/test_handler_actions.py
@@ -270,8 +270,8 @@ class TestSetBinaryStorage:
         )
 
         assert response.code == 0
-        assert app.persistence_mgr.execute_async.await_count == 2
-        insert_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[1].args[0])
+        assert app.persistence_mgr.execute_async.await_count == 3
+        insert_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[2].args[0])
         assert insert_params['workspace_uuid'] == 'workspace-a'
         assert insert_params['unique_key'] == canonical_binary_key(
             'plugin',
@@ -300,6 +300,32 @@ class TestSetBinaryStorage:
         assert expected_key in select_params.values()
         assert expected_key in update_params.values()
         assert update_params['value'] == b'new'
+
+    @pytest.mark.asyncio
+    async def test_adopts_legacy_storage_before_updating(self, app):
+        """A migrated pre-tenancy row is updated in place rather than duplicated."""
+        runtime_handler = make_handler(app)
+        legacy_storage = SimpleNamespace(
+            unique_key='plugin:test-author/test-plugin:test-key',
+            value=b'old',
+        )
+        app.persistence_mgr.execute_async.side_effect = [
+            make_result(),
+            make_result(legacy_storage),
+            make_result(),
+            make_result(),
+        ]
+
+        response = await runtime_handler.actions[RuntimeToLangBotAction.SET_BINARY_STORAGE.value](self.payload(b'new'))
+
+        assert response.code == 0
+        assert app.persistence_mgr.execute_async.await_count == 4
+        adoption_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[2].args[0])
+        value_update_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[3].args[0])
+        expected_key = canonical_binary_key('plugin', 'test-author/test-plugin', 'test-key')
+        assert expected_key in adoption_params.values()
+        assert expected_key in value_update_params.values()
+        assert value_update_params['value'] == b'new'
 
     @pytest.mark.asyncio
     async def test_invalid_max_value_bytes_falls_back_to_default_limit(self, app):
@@ -524,6 +550,29 @@ class TestGetBinaryStorage:
             )
             in statement_params.values()
         )
+
+    @pytest.mark.asyncio
+    async def test_adopts_legacy_storage_before_returning_value(self, app):
+        runtime_handler = make_handler(app)
+        legacy_storage = SimpleNamespace(
+            unique_key='plugin:test-author/test-plugin:test-key',
+            value=b'legacy bytes',
+        )
+        app.persistence_mgr.execute_async.side_effect = [
+            make_result(),
+            make_result(legacy_storage),
+            make_result(),
+        ]
+
+        response = await runtime_handler.actions[RuntimeToLangBotAction.GET_BINARY_STORAGE.value](
+            {'key': 'test-key', 'owner_type': 'plugin', 'owner': 'ignored'}
+        )
+
+        assert response.code == 0
+        assert base64.b64decode(response.data['value_base64']) == b'legacy bytes'
+        assert app.persistence_mgr.execute_async.await_count == 3
+        adoption_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[2].args[0])
+        assert canonical_binary_key('plugin', 'test-author/test-plugin', 'test-key') in adoption_params.values()
 
     @pytest.mark.asyncio
     async def test_returns_error_when_not_found(self, app):


### PR DESCRIPTION
## Summary
- fall back to the trusted pre-tenancy storage key within the already-bound Workspace
- adopt the row to the canonical tenant key on first get/set
- avoid creating duplicate old/new records while preserving payload bytes

## Verification
- plugin storage/tenancy/resource migration matrix: 43 passed
- Ruff, format and git diff --check pass