### PR TITLE
fix(plugin): keep pre-tenancy plugin storage readable

### DIFF
--- a/src/langbot/pkg/plugin/handler.py
+++ b/src/langbot/pkg/plugin/handler.py
@@ -431,6 +431,19 @@ class RuntimeConnectionHandler(handler.Handler):
             return f'{identity.plugin_author}/{identity.plugin_name}'
         raise ValueError(f'Unsupported binary storage owner_type {owner_type!r}')
 
+    @staticmethod
+    def _legacy_binary_storage_key(
+        action_context: ActionContext,
+        *,
+        owner_type: str,
+        owner: str,
+        key: str,
+    ) -> str:
+        """Return the pre-tenancy key shape for a row already scoped to this Workspace."""
+
+        legacy_owner = action_context.workspace_uuid if owner_type == 'workspace' else owner
+        return f'{owner_type}:{legacy_owner}:{key}'
+
     @classmethod
     def _binary_storage_key(
         cls,
@@ -896,8 +909,32 @@ class RuntimeConnectionHandler(handler.Handler):
                 .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
                 .where(persistence_bstorage.BinaryStorage.unique_key == unique_key)
             )
+            storage = result.first()
+            if storage is None:
+                legacy_key = self._legacy_binary_storage_key(
+                    action_context,
+                    owner_type=owner_type,
+                    owner=owner,
+                    key=key,
+                )
+                result = await self.ap.persistence_mgr.execute_async(
+                    sqlalchemy.select(persistence_bstorage.BinaryStorage)
+                    .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
+                    .where(persistence_bstorage.BinaryStorage.unique_key == legacy_key)
+                    .where(persistence_bstorage.BinaryStorage.key == key)
+                    .where(persistence_bstorage.BinaryStorage.owner_type == owner_type)
+                    .where(persistence_bstorage.BinaryStorage.owner == owner)
+                )
+                storage = result.first()
+                if storage is not None:
+                    await self.ap.persistence_mgr.execute_async(
+                        sqlalchemy.update(persistence_bstorage.BinaryStorage)
+                        .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
+                        .where(persistence_bstorage.BinaryStorage.unique_key == legacy_key)
+                        .values(unique_key=unique_key)
+                    )
 
-            if result.first() is not None:
+            if storage is not None:
                 await self.ap.persistence_mgr.execute_async(
                     sqlalchemy.update(persistence_bstorage.BinaryStorage)
                     .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
@@ -946,6 +983,29 @@ class RuntimeConnectionHandler(handler.Handler):
             )
 
             storage = result.first()
+            if storage is None:
+                legacy_key = self._legacy_binary_storage_key(
+                    action_context,
+                    owner_type=owner_type,
+                    owner=owner,
+                    key=key,
+                )
+                result = await self.ap.persistence_mgr.execute_async(
+                    sqlalchemy.select(persistence_bstorage.BinaryStorage)
+                    .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
+                    .where(persistence_bstorage.BinaryStorage.unique_key == legacy_key)
+                    .where(persistence_bstorage.BinaryStorage.key == key)
+                    .where(persistence_bstorage.BinaryStorage.owner_type == owner_type)
+                    .where(persistence_bstorage.BinaryStorage.owner == owner)
+                )
+                storage = result.first()
+                if storage is not None:
+                    await self.ap.persistence_mgr.execute_async(
+                        sqlalchemy.update(persistence_bstorage.BinaryStorage)
+                        .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
+                        .where(persistence_bstorage.BinaryStorage.unique_key == legacy_key)
+                        .values(unique_key=unique_key)
+                    )
             if storage is None:
                 return handler.ActionResponse.error(
                     message=f'Storage with key {key} not found',

--- a/src/langbot/pkg/plugin/handler.py
+++ b/src/langbot/pkg/plugin/handler.py
@@ -938,6 +938,17 @@ class RuntimeConnectionHandler(handler.Handler):
                     )
                     if update_result.rowcount:
                         return handler.ActionResponse.success(data={})
+                    canonical_update = await self.ap.persistence_mgr.execute_async(
+                        sqlalchemy.update(persistence_bstorage.BinaryStorage)
+                        .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
+                        .where(persistence_bstorage.BinaryStorage.unique_key == unique_key)
+                        .where(persistence_bstorage.BinaryStorage.key == key)
+                        .where(persistence_bstorage.BinaryStorage.owner_type == owner_type)
+                        .where(persistence_bstorage.BinaryStorage.owner == owner)
+                        .values(value=value)
+                    )
+                    if canonical_update.rowcount:
+                        return handler.ActionResponse.success(data={})
                     storage = None
 
             if storage is not None:

--- a/src/langbot/pkg/plugin/handler.py
+++ b/src/langbot/pkg/plugin/handler.py
@@ -927,12 +927,18 @@ class RuntimeConnectionHandler(handler.Handler):
                 )
                 storage = result.first()
                 if storage is not None:
-                    await self.ap.persistence_mgr.execute_async(
+                    update_result = await self.ap.persistence_mgr.execute_async(
                         sqlalchemy.update(persistence_bstorage.BinaryStorage)
                         .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
                         .where(persistence_bstorage.BinaryStorage.unique_key == legacy_key)
-                        .values(unique_key=unique_key)
+                        .where(persistence_bstorage.BinaryStorage.key == key)
+                        .where(persistence_bstorage.BinaryStorage.owner_type == owner_type)
+                        .where(persistence_bstorage.BinaryStorage.owner == owner)
+                        .values(unique_key=unique_key, value=value)
                     )
+                    if update_result.rowcount:
+                        return handler.ActionResponse.success(data={})
+                    storage = None
 
             if storage is not None:
                 await self.ap.persistence_mgr.execute_async(

--- a/src/langbot/pkg/plugin/handler.py
+++ b/src/langbot/pkg/plugin/handler.py
@@ -11,6 +11,8 @@ import traceback
 from dataclasses import dataclass
 
 import sqlalchemy
+import sqlalchemy.dialects.postgresql
+import sqlalchemy.dialects.sqlite
 
 from langbot_plugin.runtime.io import handler
 from langbot_plugin.runtime.io.connection import Connection
@@ -956,19 +958,35 @@ class RuntimeConnectionHandler(handler.Handler):
                     sqlalchemy.update(persistence_bstorage.BinaryStorage)
                     .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
                     .where(persistence_bstorage.BinaryStorage.unique_key == unique_key)
+                    .where(persistence_bstorage.BinaryStorage.key == key)
+                    .where(persistence_bstorage.BinaryStorage.owner_type == owner_type)
+                    .where(persistence_bstorage.BinaryStorage.owner == owner)
                     .values(value=value)
                 )
-            else:
-                await self.ap.persistence_mgr.execute_async(
-                    sqlalchemy.insert(persistence_bstorage.BinaryStorage).values(
-                        workspace_uuid=action_context.workspace_uuid,
-                        unique_key=unique_key,
-                        key=key,
-                        owner_type=owner_type,
-                        owner=owner,
-                        value=value,
-                    )
+                return handler.ActionResponse.success(data={})
+
+            dialect_name = self.ap.persistence_mgr.get_db_engine().dialect.name
+            insert = {
+                'postgresql': sqlalchemy.dialects.postgresql.insert,
+                'sqlite': sqlalchemy.dialects.sqlite.insert,
+            }.get(dialect_name)
+            if insert is None:
+                return handler.ActionResponse.error(message=f'Unsupported storage database dialect: {dialect_name}')
+            await self.ap.persistence_mgr.execute_async(
+                insert(persistence_bstorage.BinaryStorage)
+                .values(
+                    workspace_uuid=action_context.workspace_uuid,
+                    unique_key=unique_key,
+                    key=key,
+                    owner_type=owner_type,
+                    owner=owner,
+                    value=value,
                 )
+                .on_conflict_do_update(
+                    index_elements=['workspace_uuid', 'unique_key'],
+                    set_={'value': value},
+                )
+            )
 
             return handler.ActionResponse.success(
                 data={},

--- a/src/langbot/pkg/plugin/handler.py
+++ b/src/langbot/pkg/plugin/handler.py
@@ -1041,10 +1041,19 @@ class RuntimeConnectionHandler(handler.Handler):
                     message=str(e),
                 )
 
+            legacy_key = self._legacy_binary_storage_key(
+                action_context,
+                owner_type=owner_type,
+                owner=owner,
+                key=key,
+            )
             await self.ap.persistence_mgr.execute_async(
                 sqlalchemy.delete(persistence_bstorage.BinaryStorage)
                 .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
-                .where(persistence_bstorage.BinaryStorage.unique_key == unique_key)
+                .where(persistence_bstorage.BinaryStorage.unique_key.in_((unique_key, legacy_key)))
+                .where(persistence_bstorage.BinaryStorage.key == key)
+                .where(persistence_bstorage.BinaryStorage.owner_type == owner_type)
+                .where(persistence_bstorage.BinaryStorage.owner == owner)
             )
 
             return handler.ActionResponse.success(

--- a/src/langbot/pkg/plugin/handler.py
+++ b/src/langbot/pkg/plugin/handler.py
@@ -1034,6 +1034,13 @@ class RuntimeConnectionHandler(handler.Handler):
                     .where(persistence_bstorage.BinaryStorage.owner == owner)
                 )
                 storage = result.first()
+                if storage is None:
+                    retry_result = await self.ap.persistence_mgr.execute_async(
+                        sqlalchemy.select(persistence_bstorage.BinaryStorage)
+                        .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
+                        .where(persistence_bstorage.BinaryStorage.unique_key == unique_key)
+                    )
+                    storage = retry_result.first()
             if storage is None:
                 return handler.ActionResponse.error(
                     message=f'Storage with key {key} not found',

--- a/src/langbot/pkg/plugin/handler.py
+++ b/src/langbot/pkg/plugin/handler.py
@@ -1116,7 +1116,7 @@ class RuntimeConnectionHandler(handler.Handler):
 
             return handler.ActionResponse.success(
                 data={
-                    'keys': result.scalars().all(),
+                    'keys': list(dict.fromkeys(result.scalars().all())),
                 },
             )
 

--- a/src/langbot/pkg/plugin/handler.py
+++ b/src/langbot/pkg/plugin/handler.py
@@ -999,13 +999,6 @@ class RuntimeConnectionHandler(handler.Handler):
                     .where(persistence_bstorage.BinaryStorage.owner == owner)
                 )
                 storage = result.first()
-                if storage is not None:
-                    await self.ap.persistence_mgr.execute_async(
-                        sqlalchemy.update(persistence_bstorage.BinaryStorage)
-                        .where(persistence_bstorage.BinaryStorage.workspace_uuid == action_context.workspace_uuid)
-                        .where(persistence_bstorage.BinaryStorage.unique_key == legacy_key)
-                        .values(unique_key=unique_key)
-                    )
             if storage is None:
                 return handler.ActionResponse.error(
                     message=f'Storage with key {key} not found',

--- a/tests/unit_tests/plugin/test_handler_actions.py
+++ b/tests/unit_tests/plugin/test_handler_actions.py
@@ -234,6 +234,7 @@ class TestSetBinaryStorage:
             },
         }
         mock_app.persistence_mgr = Mock()
+        mock_app.persistence_mgr.get_db_engine.return_value = SimpleNamespace(dialect=SimpleNamespace(name='sqlite'))
         mock_app.persistence_mgr.execute_async = AsyncMock(return_value=make_result())
         mock_app.logger = Mock()
         return mock_app
@@ -322,6 +323,7 @@ class TestSetBinaryStorage:
         assert expected_key in adoption_params.values()
         assert adoption_params['value'] == b'new'
 
+    @pytest.mark.asyncio
     async def test_legacy_adoption_race_updates_winning_canonical_row(self, app):
         runtime_handler = make_handler(app)
         legacy_storage = SimpleNamespace(unique_key='plugin:test-author/test-plugin:test-key')

--- a/tests/unit_tests/plugin/test_handler_actions.py
+++ b/tests/unit_tests/plugin/test_handler_actions.py
@@ -616,16 +616,19 @@ class TestDeleteAndListBinaryStorage:
 
         assert response.code == 0
         statement_params = compiled_params(app.persistence_mgr.execute_async.await_args.args[0])
-        assert 'workspace-a' in statement_params.values()
+        flat_values = [
+            item for value in statement_params.values() for item in (value if isinstance(value, list) else [value])
+        ]
+        assert 'workspace-a' in flat_values
         assert (
             canonical_binary_key(
                 'plugin',
                 'test-author/test-plugin',
                 'test-key',
             )
-            in statement_params.values()
+            in flat_values
         )
-        assert 'forged-owner' not in statement_params.values()
+        assert 'forged-owner' not in flat_values
 
     @pytest.mark.asyncio
     async def test_delete_removes_canonical_and_legacy_scoped_keys(self, app):
@@ -641,7 +644,9 @@ class TestDeleteAndListBinaryStorage:
 
         assert response.code == 0
         statement_params = compiled_params(app.persistence_mgr.execute_async.await_args.args[0])
-        values = set(statement_params.values())
+        values = [
+            item for value in statement_params.values() for item in (value if isinstance(value, list) else [value])
+        ]
         assert 'workspace-a' in values
         assert canonical_binary_key('plugin', 'test-author/test-plugin', 'test-key') in values
         assert 'plugin:test-author/test-plugin:test-key' in values

--- a/tests/unit_tests/plugin/test_handler_actions.py
+++ b/tests/unit_tests/plugin/test_handler_actions.py
@@ -322,6 +322,26 @@ class TestSetBinaryStorage:
         assert expected_key in adoption_params.values()
         assert adoption_params['value'] == b'new'
 
+    async def test_legacy_adoption_race_updates_winning_canonical_row(self, app):
+        runtime_handler = make_handler(app)
+        legacy_storage = SimpleNamespace(unique_key='plugin:test-author/test-plugin:test-key')
+        lost_race = SimpleNamespace(rowcount=0)
+        canonical_winner = SimpleNamespace(rowcount=1)
+        app.persistence_mgr.execute_async.side_effect = [
+            make_result(),
+            make_result(legacy_storage),
+            lost_race,
+            canonical_winner,
+        ]
+
+        response = await runtime_handler.actions[RuntimeToLangBotAction.SET_BINARY_STORAGE.value](self.payload(b'new'))
+
+        assert response.code == 0
+        assert app.persistence_mgr.execute_async.await_count == 4
+        winner_update = compiled_params(app.persistence_mgr.execute_async.await_args_list[3].args[0])
+        assert canonical_binary_key('plugin', 'test-author/test-plugin', 'test-key') in winner_update.values()
+        assert winner_update['value'] == b'new'
+
     @pytest.mark.asyncio
     async def test_legacy_adoption_lost_to_delete_inserts_new_value(self, app):
         runtime_handler = make_handler(app)
@@ -331,14 +351,15 @@ class TestSetBinaryStorage:
             make_result(),
             make_result(legacy_storage),
             lost_race,
+            SimpleNamespace(rowcount=0),
             make_result(),
         ]
 
         response = await runtime_handler.actions[RuntimeToLangBotAction.SET_BINARY_STORAGE.value](self.payload(b'new'))
 
         assert response.code == 0
-        assert app.persistence_mgr.execute_async.await_count == 4
-        insert_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[3].args[0])
+        assert app.persistence_mgr.execute_async.await_count == 5
+        insert_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[4].args[0])
         assert insert_params['unique_key'] == canonical_binary_key('plugin', 'test-author/test-plugin', 'test-key')
         assert insert_params['value'] == b'new'
 

--- a/tests/unit_tests/plugin/test_handler_actions.py
+++ b/tests/unit_tests/plugin/test_handler_actions.py
@@ -610,6 +610,26 @@ class TestGetBinaryStorage:
         assert app.persistence_mgr.execute_async.await_count == 2
 
     @pytest.mark.asyncio
+    async def test_retries_canonical_after_concurrent_legacy_adoption(self, app):
+        runtime_handler = make_handler(app)
+        canonical_storage = SimpleNamespace(value=b'adopted bytes')
+        app.persistence_mgr.execute_async.side_effect = [
+            make_result(),
+            make_result(),
+            make_result(canonical_storage),
+        ]
+
+        response = await runtime_handler.actions[RuntimeToLangBotAction.GET_BINARY_STORAGE.value](
+            {'key': 'test-key', 'owner_type': 'plugin', 'owner': 'ignored'}
+        )
+
+        assert response.code == 0
+        assert base64.b64decode(response.data['value_base64']) == b'adopted bytes'
+        assert app.persistence_mgr.execute_async.await_count == 3
+        retry_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[2].args[0])
+        assert canonical_binary_key('plugin', 'test-author/test-plugin', 'test-key') in retry_params.values()
+
+    @pytest.mark.asyncio
     async def test_returns_error_when_not_found(self, app):
         """Missing binary storage rows return an error response."""
         runtime_handler = make_handler(app)

--- a/tests/unit_tests/plugin/test_handler_actions.py
+++ b/tests/unit_tests/plugin/test_handler_actions.py
@@ -270,8 +270,8 @@ class TestSetBinaryStorage:
         )
 
         assert response.code == 0
-        assert app.persistence_mgr.execute_async.await_count == 2
-        insert_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[1].args[0])
+        assert app.persistence_mgr.execute_async.await_count == 3
+        insert_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[2].args[0])
         assert insert_params['workspace_uuid'] == 'workspace-a'
         assert insert_params['unique_key'] == canonical_binary_key(
             'plugin',
@@ -300,6 +300,32 @@ class TestSetBinaryStorage:
         assert expected_key in select_params.values()
         assert expected_key in update_params.values()
         assert update_params['value'] == b'new'
+
+    @pytest.mark.asyncio
+    async def test_adopts_legacy_storage_before_updating(self, app):
+        """A migrated pre-tenancy row is updated in place rather than duplicated."""
+        runtime_handler = make_handler(app)
+        legacy_storage = SimpleNamespace(
+            unique_key='plugin:test-author/test-plugin:test-key',
+            value=b'old',
+        )
+        app.persistence_mgr.execute_async.side_effect = [
+            make_result(),
+            make_result(legacy_storage),
+            make_result(),
+            make_result(),
+        ]
+
+        response = await runtime_handler.actions[RuntimeToLangBotAction.SET_BINARY_STORAGE.value](self.payload(b'new'))
+
+        assert response.code == 0
+        assert app.persistence_mgr.execute_async.await_count == 4
+        adoption_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[2].args[0])
+        value_update_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[3].args[0])
+        expected_key = canonical_binary_key('plugin', 'test-author/test-plugin', 'test-key')
+        assert expected_key in adoption_params.values()
+        assert expected_key in value_update_params.values()
+        assert value_update_params['value'] == b'new'
 
     @pytest.mark.asyncio
     async def test_invalid_max_value_bytes_falls_back_to_default_limit(self, app):
@@ -524,6 +550,29 @@ class TestGetBinaryStorage:
             )
             in statement_params.values()
         )
+
+    @pytest.mark.asyncio
+    async def test_adopts_legacy_storage_before_returning_value(self, app):
+        runtime_handler = make_handler(app)
+        legacy_storage = SimpleNamespace(
+            unique_key='plugin:test-author/test-plugin:test-key',
+            value=b'legacy bytes',
+        )
+        app.persistence_mgr.execute_async.side_effect = [
+            make_result(),
+            make_result(legacy_storage),
+            make_result(),
+        ]
+
+        response = await runtime_handler.actions[RuntimeToLangBotAction.GET_BINARY_STORAGE.value](
+            {'key': 'test-key', 'owner_type': 'plugin', 'owner': 'ignored'}
+        )
+
+        assert response.code == 0
+        assert base64.b64decode(response.data['value_base64']) == b'legacy bytes'
+        assert app.persistence_mgr.execute_async.await_count == 3
+        adoption_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[2].args[0])
+        assert canonical_binary_key('plugin', 'test-author/test-plugin', 'test-key') in adoption_params.values()
 
     @pytest.mark.asyncio
     async def test_returns_error_when_not_found(self, app):

--- a/tests/unit_tests/plugin/test_handler_actions.py
+++ b/tests/unit_tests/plugin/test_handler_actions.py
@@ -711,7 +711,7 @@ class TestDeleteAndListBinaryStorage:
     @pytest.mark.asyncio
     async def test_list_keys_uses_trusted_plugin_owner(self, app):
         result = Mock()
-        result.scalars.return_value.all.return_value = ['first', 'second']
+        result.scalars.return_value.all.return_value = ['first', 'second', 'first']
         app.persistence_mgr.execute_async.return_value = result
         runtime_handler = make_handler(app)
 

--- a/tests/unit_tests/plugin/test_handler_actions.py
+++ b/tests/unit_tests/plugin/test_handler_actions.py
@@ -552,7 +552,7 @@ class TestGetBinaryStorage:
         )
 
     @pytest.mark.asyncio
-    async def test_adopts_legacy_storage_before_returning_value(self, app):
+    async def test_reads_legacy_storage_without_mutating_key(self, app):
         runtime_handler = make_handler(app)
         legacy_storage = SimpleNamespace(
             unique_key='plugin:test-author/test-plugin:test-key',
@@ -561,7 +561,6 @@ class TestGetBinaryStorage:
         app.persistence_mgr.execute_async.side_effect = [
             make_result(),
             make_result(legacy_storage),
-            make_result(),
         ]
 
         response = await runtime_handler.actions[RuntimeToLangBotAction.GET_BINARY_STORAGE.value](
@@ -570,9 +569,7 @@ class TestGetBinaryStorage:
 
         assert response.code == 0
         assert base64.b64decode(response.data['value_base64']) == b'legacy bytes'
-        assert app.persistence_mgr.execute_async.await_count == 3
-        adoption_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[2].args[0])
-        assert canonical_binary_key('plugin', 'test-author/test-plugin', 'test-key') in adoption_params.values()
+        assert app.persistence_mgr.execute_async.await_count == 2
 
     @pytest.mark.asyncio
     async def test_returns_error_when_not_found(self, app):

--- a/tests/unit_tests/plugin/test_handler_actions.py
+++ b/tests/unit_tests/plugin/test_handler_actions.py
@@ -628,6 +628,27 @@ class TestDeleteAndListBinaryStorage:
         assert 'forged-owner' not in statement_params.values()
 
     @pytest.mark.asyncio
+    async def test_delete_removes_canonical_and_legacy_scoped_keys(self, app):
+        runtime_handler = make_handler(app)
+
+        response = await runtime_handler.actions[RuntimeToLangBotAction.DELETE_BINARY_STORAGE.value](
+            {
+                'key': 'test-key',
+                'owner_type': 'plugin',
+                'owner': 'forged-owner',
+            }
+        )
+
+        assert response.code == 0
+        statement_params = compiled_params(app.persistence_mgr.execute_async.await_args.args[0])
+        values = set(statement_params.values())
+        assert 'workspace-a' in values
+        assert canonical_binary_key('plugin', 'test-author/test-plugin', 'test-key') in values
+        assert 'plugin:test-author/test-plugin:test-key' in values
+        assert 'test-author/test-plugin' in values
+        assert 'forged-owner' not in values
+
+    @pytest.mark.asyncio
     async def test_list_keys_uses_trusted_plugin_owner(self, app):
         result = Mock()
         result.scalars.return_value.all.return_value = ['first', 'second']

--- a/tests/unit_tests/plugin/test_handler_actions.py
+++ b/tests/unit_tests/plugin/test_handler_actions.py
@@ -305,14 +305,32 @@ class TestSetBinaryStorage:
     async def test_adopts_legacy_storage_before_updating(self, app):
         """A migrated pre-tenancy row is updated in place rather than duplicated."""
         runtime_handler = make_handler(app)
-        legacy_storage = SimpleNamespace(
-            unique_key='plugin:test-author/test-plugin:test-key',
-            value=b'old',
-        )
+        legacy_storage = SimpleNamespace(unique_key='plugin:test-author/test-plugin:test-key')
+        adopted = SimpleNamespace(rowcount=1)
         app.persistence_mgr.execute_async.side_effect = [
             make_result(),
             make_result(legacy_storage),
+            adopted,
+        ]
+
+        response = await runtime_handler.actions[RuntimeToLangBotAction.SET_BINARY_STORAGE.value](self.payload(b'new'))
+
+        assert response.code == 0
+        assert app.persistence_mgr.execute_async.await_count == 3
+        adoption_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[2].args[0])
+        expected_key = canonical_binary_key('plugin', 'test-author/test-plugin', 'test-key')
+        assert expected_key in adoption_params.values()
+        assert adoption_params['value'] == b'new'
+
+    @pytest.mark.asyncio
+    async def test_legacy_adoption_lost_to_delete_inserts_new_value(self, app):
+        runtime_handler = make_handler(app)
+        legacy_storage = SimpleNamespace(unique_key='plugin:test-author/test-plugin:test-key')
+        lost_race = SimpleNamespace(rowcount=0)
+        app.persistence_mgr.execute_async.side_effect = [
             make_result(),
+            make_result(legacy_storage),
+            lost_race,
             make_result(),
         ]
 
@@ -320,12 +338,9 @@ class TestSetBinaryStorage:
 
         assert response.code == 0
         assert app.persistence_mgr.execute_async.await_count == 4
-        adoption_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[2].args[0])
-        value_update_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[3].args[0])
-        expected_key = canonical_binary_key('plugin', 'test-author/test-plugin', 'test-key')
-        assert expected_key in adoption_params.values()
-        assert expected_key in value_update_params.values()
-        assert value_update_params['value'] == b'new'
+        insert_params = compiled_params(app.persistence_mgr.execute_async.await_args_list[3].args[0])
+        assert insert_params['unique_key'] == canonical_binary_key('plugin', 'test-author/test-plugin', 'test-key')
+        assert insert_params['value'] == b'new'
 
     @pytest.mark.asyncio
     async def test_invalid_max_value_bytes_falls_back_to_default_limit(self, app):


### PR DESCRIPTION
## Summary
- fall back to the trusted pre-tenancy storage key within the already-bound Workspace
- adopt the row to the canonical tenant key on first get/set
- delete both canonical and legacy scoped keys to avoid row resurrection
- preserve payload bytes and avoid duplicate old/new records

## Verification
- plugin storage/tenancy/resource migration matrix: 44 passed
- Ruff, format and git diff --check pass
- supersedes #2445 after independent review