### PR TITLE
fix(wecom): read media_id instead of media in send_message()

### DIFF
--- a/src/langbot/pkg/platform/sources/wecom.py
+++ b/src/langbot/pkg/platform/sources/wecom.py
@@ -274,11 +274,11 @@ class WecomAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
                 if content['type'] == 'text':
                     await self.bot.send_private_msg(user_id, agent_id, content['content'])
                 if content['type'] == 'image':
-                    await self.bot.send_image(user_id, agent_id, content['media'])
+                    await self.bot.send_image(user_id, agent_id, content['media_id'])
                 if content['type'] == 'voice':
-                    await self.bot.send_voice(user_id, agent_id, content['media'])
+                    await self.bot.send_voice(user_id, agent_id, content['media_id'])
                 if content['type'] == 'file':
-                    await self.bot.send_file(user_id, agent_id, content['media'])
+                    await self.bot.send_file(user_id, agent_id, content['media_id'])
 
     def register_listener(
         self,

--- a/tests/unit_tests/platform/test_wecom_send_message.py
+++ b/tests/unit_tests/platform/test_wecom_send_message.py
@@ -1,0 +1,59 @@
+"""Tests for WecomAdapter.send_message content-key handling."""
+
+import pytest
+
+import langbot_plugin.api.entities.builtin.platform.message as platform_message
+from langbot.pkg.platform.sources.wecom import WecomAdapter
+
+
+class StubWecomClient:
+    def __init__(self):
+        self.calls = []
+
+    async def get_media_id(self, msg):
+        return 'MEDIA_ID_123'
+
+    async def send_private_msg(self, user_id, agent_id, text):
+        self.calls.append(('text', user_id, agent_id, text))
+
+    async def send_image(self, user_id, agent_id, media_id):
+        self.calls.append(('image', user_id, agent_id, media_id))
+
+    async def send_voice(self, user_id, agent_id, media_id):
+        self.calls.append(('voice', user_id, agent_id, media_id))
+
+    async def send_file(self, user_id, agent_id, media_id):
+        self.calls.append(('file', user_id, agent_id, media_id))
+
+
+def _make_adapter():
+    adapter = WecomAdapter.model_construct(bot=StubWecomClient())
+    return adapter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('part', 'expected_type'),
+    [
+        (platform_message.Image(url='https://example.com/x.jpg'), 'image'),
+        (platform_message.Voice(url='https://example.com/x.amr'), 'voice'),
+        (platform_message.File(url='https://example.com/x.pdf', name='x.pdf'), 'file'),
+    ],
+)
+async def test_send_message_dispatches_media_by_id(part, expected_type):
+    adapter = _make_adapter()
+    chain = platform_message.MessageChain([part])
+
+    await adapter.send_message('person', 'USER1|1000001', chain)
+
+    assert adapter.bot.calls == [(expected_type, 'USER1', 1000001, 'MEDIA_ID_123')]
+
+
+@pytest.mark.asyncio
+async def test_send_message_text_still_works():
+    adapter = _make_adapter()
+    chain = platform_message.MessageChain([platform_message.Plain(text='hello')])
+
+    await adapter.send_message('person', 'USER1|1000001', chain)
+
+    assert adapter.bot.calls == [('text', 'USER1', 1000001, 'hello')]


### PR DESCRIPTION
## 概述 / Overview

`WecomAdapter.send_message()`, the entry point plugins use via `PluginToRuntimeAction.SEND_MESSAGE`, raises `KeyError: 'media'` for any image, voice, or file message part.

`WecomMessageConverter.yiri2target()` always builds these parts as `{'type': 'image'|'voice'|'file', 'media_id': ...}` (only ever `media_id`), and the sibling method `reply_message()` reads that key correctly. `send_message()` instead reads `content['media']`, a key that is never produced, so the call raises before reaching `self.bot.send_image/send_voice/send_file`.

This fixes the `plugin.send_message` symptom in #1687 (falls back to sending the unprocessed text because the call raises). The `event_context.reply` multi-part `msg_id` duplicate symptom in the same issue is a different, unconfirmed mechanism (a WeCom-side same-`msg_id` reply constraint, not this key mismatch) and is out of scope here.

## 检查清单 / Checklist

### PR 作者完成 / For PR author

- [x] 阅读仓库贡献指引了吗？ / Have you read the contribution guide?
- [x] 我已签署或将在机器人提示后签署 CLA。 / I have signed, or will sign when prompted by the bot, the CLA.
- [ ] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

## Verification

- New test `tests/unit_tests/platform/test_wecom_send_message.py` fails on unmodified HEAD (`KeyError: 'media'` for image/voice/file) and passes after the fix; text-only send is covered too.
- `uv run pytest tests/unit_tests/ tests/smoke/` (Python 3.12): 2788 passed, 1 skipped. `tests/unit_tests/platform/` also re-run clean on Python 3.11 and 3.13.
- `uv run ruff check` / `ruff format --check`: clean.
- Not verified: an actual WeCom self-built-app account (no test tenant available here), and the separate `msg_id`-duplicate symptom in #1687.
