### PR TITLE
chore: release v4.10.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot"
-version = "4.10.7"
+version = "4.10.8"
 description = "Production-grade platform for building agentic IM bots"
 readme = "README.md"
 license-files = ["LICENSE"]

--- a/uv.lock
+++ b/uv.lock
@@ -2008,7 +2008,7 @@ wheels = [
 
 [[package]]
 name = "langbot"
-version = "4.10.7"
+version = "4.10.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiocqhttp" },


### PR DESCRIPTION
## Summary

- bump LangBot package version from 4.10.7 to 4.10.8
- refresh the uv lockfile version metadata

## Pre-release verification

- SQLite fresh/legacy migrations: 36 passed
- PostgreSQL/pgvector fresh/legacy/release migrations: 24 passed
- plugin storage compatibility: 28 passed
- isolated fresh-instance E2E startup: 13 passed
- WeCom media/Box/wrapper regressions: 6 passed
- Ruff and frontend lint/build passed
- wheel and sdist passed metadata checks; clean wheel install reports 4.10.8 and contains WebUI assets

The tag and release will only be created after required checks pass on the merged master commit.