### PR TITLE
fix(qqofficial): send complete stream snapshots

### DIFF
--- a/src/langbot/pkg/platform/sources/qqofficial.py
+++ b/src/langbot/pkg/platform/sources/qqofficial.py
@@ -650,13 +650,13 @@ class QQOfficialAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter
             # 用第一个 chunk 的文本建立会话（不发 "..." 避免污染前缀）
             ctx['session_started'] = True
 
-        # 发送内容 = 全量累积文本
-        # QQ API 的 replace 模式不允许修改已下发前缀，所以：
-        # - 首次：发送全部文本，建立会话
-        # - 后续：只能发送新增部分（append 行为）
-        content_to_send = ctx['accumulated_text'][ctx['sent_length'] :]
-        if not content_to_send and not is_final:
+        # `replace` mode requires every update to contain the previously
+        # delivered content as its prefix. `sent_length` only tells us whether
+        # a non-final snapshot has new content; it must not truncate the
+        # content sent to QQ.
+        if len(ctx['accumulated_text']) <= ctx['sent_length'] and not is_final:
             return
+        content_to_send = ctx['accumulated_text']
 
         input_state = 10 if is_final else 1
 

--- a/tests/unit_tests/platform/test_qqofficial_api.py
+++ b/tests/unit_tests/platform/test_qqofficial_api.py
@@ -108,7 +108,7 @@ def _stream_test_adapter():
 
 
 @pytest.mark.asyncio
-async def test_qq_stream_uses_cumulative_chunks_as_snapshots():
+async def test_qq_stream_replace_mode_sends_complete_snapshots():
     adapter = _stream_test_adapter()
     adapter._stream_ctx['message-1'] = {
         'user_openid': 'user-1',
@@ -138,7 +138,7 @@ async def test_qq_stream_uses_cumulative_chunks_as_snapshots():
 
     assert [call.kwargs['content'] for call in adapter.bot.send_stream_msg.await_args_list] == [
         '<think>one',
-        ' two',
+        '<think>one two',
     ]
 
 


### PR DESCRIPTION
## 概述 / Overview

> 请在此部分填写你实现/解决/优化的内容:  
> Summary of what you implemented/solved/optimized:
> #2454
- 在 QQ Official 流式接口的 `replace` 模式下，每次更新均发送完整的累计文本。
- `sent_length` 仅用于跳过没有新增内容的非最终更新，不再用于截断发送内容。
- 新增单元测试，确保后续更新仍发送完整文本快照。

### 更改前后对比截图 / Screenshots

> 请在此部分粘贴更改前后对比截图（可以是界面截图、控制台输出、对话截图等）:  
> Please paste the screenshots of changes before and after here (can be interface screenshots, console output, conversation screenshots, etc.):
> 
> 修改前 / Before:
> 详见 issue #2454
> 修改后 / After:
> 

https://github.com/user-attachments/assets/35129797-f7f0-4af4-97c3-ce1802d36629



## 检查清单 / Checklist

### PR 作者完成 / For PR author

*请在方括号间写`x`以打勾 / Please tick the box with `x`*

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [x] 我已签署或将在机器人提示后签署 [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。 / I have signed, or will sign when prompted by the bot, the [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md).
- [x] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] 文档编写了吗？ / Have you written the documentation?