### PR TITLE
feat(qqofficial): add markdown reply rendering

### DIFF
--- a/src/langbot/libs/qq_official_api/api.py
+++ b/src/langbot/libs/qq_official_api/api.py
@@ -422,6 +422,69 @@ class QQOfficialClient:
                 await self.logger.error(f'Failed to send private message: {response_data}')
                 raise ValueError(response)
 
+    async def _send_markdown_msg(
+        self,
+        target_type: str,
+        target_id: str,
+        content: str,
+        msg_id: Optional[str] = None,
+        event_id: Optional[str] = None,
+        msg_seq: int = 1,
+    ) -> None:
+        """Send a Markdown message to a C2C user or QQ group."""
+        if not await self.check_access_token():
+            await self.get_access_token()
+
+        if target_type == 'c2c':
+            url = f'{self.base_url}/v2/users/{target_id}/messages'
+        elif target_type == 'group':
+            url = f'{self.base_url}/v2/groups/{target_id}/messages'
+        else:
+            raise ValueError(f'Unsupported Markdown target type: {target_type}')
+
+        data: dict[str, Any] = {
+            'msg_type': 2,
+            'markdown': {'content': content},
+            'msg_seq': msg_seq,
+        }
+        if msg_id:
+            data['msg_id'] = msg_id
+        if event_id:
+            data['event_id'] = event_id
+
+        async with self._http_client_context() as client:
+            headers = {
+                'Authorization': f'QQBot {self.access_token}',
+                'Content-Type': 'application/json',
+            }
+            response = await client.post(url, headers=headers, json=data)
+            if response.status_code != 200:
+                response_data = await httpclient.parse_json_response(response)
+                await self.logger.error(f'Failed to send Markdown message: {response_data}')
+                raise ValueError(response)
+
+    async def send_private_markdown_msg(
+        self,
+        user_openid: str,
+        content: str,
+        msg_id: Optional[str] = None,
+        event_id: Optional[str] = None,
+        msg_seq: int = 1,
+    ) -> None:
+        """Send a Markdown C2C message."""
+        await self._send_markdown_msg('c2c', user_openid, content, msg_id, event_id, msg_seq)
+
+    async def send_group_markdown_msg(
+        self,
+        group_openid: str,
+        content: str,
+        msg_id: Optional[str] = None,
+        event_id: Optional[str] = None,
+        msg_seq: int = 1,
+    ) -> None:
+        """Send a Markdown QQ group message."""
+        await self._send_markdown_msg('group', group_openid, content, msg_id, event_id, msg_seq)
+
     async def send_group_text_msg(
         self,
         group_openid: str,

--- a/src/langbot/pkg/platform/sources/qqofficial.py
+++ b/src/langbot/pkg/platform/sources/qqofficial.py
@@ -329,17 +329,12 @@ class QQOfficialAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter
             content_type = content.get('type', 'text')
 
             if content_type == 'text':
-                if target_type == 'c2c':
-                    await self.bot.send_private_text_msg(
+                if target_type in {'c2c', 'group'}:
+                    await self._send_c2c_or_group_text_reply(
+                        target_type,
                         target_id,
                         content['content'],
-                        qq_official_event.d_id,
-                    )
-                elif target_type == 'group':
-                    await self.bot.send_group_text_msg(
-                        target_id,
-                        content['content'],
-                        qq_official_event.d_id,
+                        msg_id=qq_official_event.d_id,
                     )
 
             elif content_type == 'image':
@@ -382,6 +377,39 @@ class QQOfficialAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter
 
     async def send_message(self, target_type: str, target_id: str, message: platform_message.MessageChain):
         pass
+
+    async def _send_c2c_or_group_text_reply(
+        self,
+        target_type: str,
+        target_id: str,
+        content: str,
+        *,
+        msg_id: typing.Optional[str] = None,
+        event_id: typing.Optional[str] = None,
+        msg_seq: int = 1,
+    ) -> None:
+        """Send a text reply using the configured C2C/group render mode."""
+        use_markdown = self.config.get('enable-markdown-rendering', False)
+        if target_type == 'c2c':
+            send = self.bot.send_private_markdown_msg if use_markdown else self.bot.send_private_text_msg
+            await send(
+                user_openid=target_id,
+                content=content,
+                msg_id=msg_id,
+                event_id=event_id,
+                msg_seq=msg_seq,
+            )
+        elif target_type == 'group':
+            send = self.bot.send_group_markdown_msg if use_markdown else self.bot.send_group_text_msg
+            await send(
+                group_openid=target_id,
+                content=content,
+                msg_id=msg_id,
+                event_id=event_id,
+                msg_seq=msg_seq,
+            )
+        else:
+            raise ValueError(f'Unsupported QQ Official text reply target: {target_type}')
 
     def register_listener(
         self,
@@ -778,20 +806,13 @@ class QQOfficialAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter
             return
 
         try:
-            if target_type == 'c2c':
-                await self.bot.send_private_text_msg(
-                    user_openid=target_id,
-                    content=text,
-                    event_id=event_id,
-                    msg_seq=msg_seq,
-                )
-            elif target_type == 'group':
-                await self.bot.send_group_text_msg(
-                    group_openid=target_id,
-                    content=text,
-                    event_id=event_id,
-                    msg_seq=msg_seq,
-                )
+            await self._send_c2c_or_group_text_reply(
+                target_type,
+                target_id,
+                text,
+                event_id=event_id,
+                msg_seq=msg_seq,
+            )
         except Exception:
             await self.logger.error(f'QQ Official: synthetic reply delivery failed: {traceback.format_exc()}')
 

--- a/src/langbot/pkg/platform/sources/qqofficial.yaml
+++ b/src/langbot/pkg/platform/sources/qqofficial.yaml
@@ -95,6 +95,18 @@ spec:
       type: boolean
       required: true
       default: false
+    - name: enable-markdown-rendering
+      label:
+        en_US: Enable Markdown Rendering
+        zh_Hans: 启用 Markdown 渲染
+        zh_Hant: 啟用 Markdown 渲染
+      description:
+        en_US: Render non-stream C2C and QQ group text replies as Markdown. Channel messages always use plain text and are not affected by this setting.
+        zh_Hans: 将非流式 C2C 私聊和 QQ 群聊文本回复渲染为 Markdown。频道消息始终以纯文本发送，不受此设置影响。
+        zh_Hant: 將非串流 C2C 私聊與 QQ 群聊文字回覆渲染為 Markdown。頻道訊息一律以純文字傳送，不受此設定影響。
+      type: boolean
+      required: true
+      default: false
     - name: webhook_url
       label:
         en_US: Webhook Callback URL

--- a/tests/unit_tests/platform/test_qqofficial_api.py
+++ b/tests/unit_tests/platform/test_qqofficial_api.py
@@ -1,9 +1,11 @@
-"""Tests for QQ Official keyboard payload helpers."""
+"""Tests for QQ Official message and keyboard payload helpers."""
 
 import asyncio
+import json
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 import langbot_plugin.api.entities.builtin.platform.message as platform_message
@@ -99,6 +101,12 @@ def _stream_test_adapter():
     adapter.bot = MagicMock()
     adapter.bot.send_stream_msg = AsyncMock(return_value={'id': 'stream-1'})
     adapter.bot.send_markdown_keyboard = AsyncMock(return_value={'id': 'message-1'})
+    adapter.bot.send_private_text_msg = AsyncMock()
+    adapter.bot.send_group_text_msg = AsyncMock()
+    adapter.bot.send_private_markdown_msg = AsyncMock()
+    adapter.bot.send_group_markdown_msg = AsyncMock()
+    adapter.bot.send_channle_group_text_msg = AsyncMock()
+    adapter.bot.send_channle_private_text_msg = AsyncMock()
     adapter.ap = None
     adapter._stream_ctx = {}
     adapter._stream_ctx_ts = {}
@@ -140,6 +148,105 @@ async def test_qq_stream_uses_cumulative_chunks_as_snapshots():
         '<think>one',
         ' two',
     ]
+
+
+@pytest.mark.asyncio
+async def test_qq_markdown_messages_use_markdown_payloads():
+    requests = []
+
+    def capture_request(request: httpx.Request) -> httpx.Response:
+        requests.append((str(request.url), json.loads(request.content)))
+        return httpx.Response(200, json={})
+
+    client = QQOfficialClient('secret', 'token', 'app-id', AsyncMock())
+    client.access_token = 'access-token'
+    client.access_token_expiry_time = time.time() + 3600
+    client._http_clients[None] = httpx.AsyncClient(transport=httpx.MockTransport(capture_request))
+
+    try:
+        await client.send_private_markdown_msg('user-1', '# Hello', msg_id='message-1', msg_seq=2)
+        await client.send_group_markdown_msg('group-1', '* Hello', event_id='event-1', msg_seq=3)
+    finally:
+        await client.close()
+
+    assert requests == [
+        (
+            'https://api.sgroup.qq.com/v2/users/user-1/messages',
+            {'msg_type': 2, 'markdown': {'content': '# Hello'}, 'msg_seq': 2, 'msg_id': 'message-1'},
+        ),
+        (
+            'https://api.sgroup.qq.com/v2/groups/group-1/messages',
+            {'msg_type': 2, 'markdown': {'content': '* Hello'}, 'msg_seq': 3, 'event_id': 'event-1'},
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_qq_markdown_rendering_switches_c2c_and_group_text_replies():
+    adapter = _stream_test_adapter()
+    adapter.config = {'enable-markdown-rendering': True}
+
+    await adapter._send_c2c_or_group_text_reply('c2c', 'user-1', '# Hello', msg_id='message-1')
+    await adapter._send_c2c_or_group_text_reply('group', 'group-1', '* Hello', event_id='event-1')
+
+    adapter.bot.send_private_markdown_msg.assert_awaited_once_with(
+        user_openid='user-1',
+        content='# Hello',
+        msg_id='message-1',
+        event_id=None,
+        msg_seq=1,
+    )
+    adapter.bot.send_group_markdown_msg.assert_awaited_once_with(
+        group_openid='group-1',
+        content='* Hello',
+        msg_id=None,
+        event_id='event-1',
+        msg_seq=1,
+    )
+    adapter.bot.send_private_text_msg.assert_not_awaited()
+    adapter.bot.send_group_text_msg.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_qq_markdown_rendering_defaults_to_plain_text_replies():
+    adapter = _stream_test_adapter()
+    adapter.config = {}
+
+    await adapter._send_c2c_or_group_text_reply('c2c', 'user-1', 'Hello')
+    await adapter._send_c2c_or_group_text_reply('group', 'group-1', 'Hello')
+
+    adapter.bot.send_private_text_msg.assert_awaited_once()
+    adapter.bot.send_group_text_msg.assert_awaited_once()
+    adapter.bot.send_private_markdown_msg.assert_not_awaited()
+    adapter.bot.send_group_markdown_msg.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_qq_markdown_rendering_does_not_affect_channel_messages():
+    adapter = _stream_test_adapter()
+    adapter.config = {'enable-markdown-rendering': True}
+    message = platform_message.MessageChain([platform_message.Plain(text='# Hello')])
+
+    channel_source = MagicMock()
+    channel_source.t = 'AT_MESSAGE_CREATE'
+    channel_source.channel_id = 'channel-1'
+    channel_source.d_id = 'message-1'
+    channel_event = MagicMock()
+    channel_event.source_platform_object = channel_source
+    await adapter.reply_message(channel_event, message)
+
+    dm_source = MagicMock()
+    dm_source.t = 'DIRECT_MESSAGE_CREATE'
+    dm_source.guild_id = 'guild-1'
+    dm_source.d_id = 'message-2'
+    dm_event = MagicMock()
+    dm_event.source_platform_object = dm_source
+    await adapter.reply_message(dm_event, message)
+
+    adapter.bot.send_channle_group_text_msg.assert_awaited_once_with('channel-1', '# Hello', 'message-1')
+    adapter.bot.send_channle_private_text_msg.assert_awaited_once_with('guild-1', '# Hello', 'message-2')
+    adapter.bot.send_private_markdown_msg.assert_not_awaited()
+    adapter.bot.send_group_markdown_msg.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 概述 / Overview

> 请在此部分填写你实现/解决/优化的内容:  
> Summary of what you implemented/solved/optimized:
> 
实现了 #2456 中提的需求：
 - 为 QQ Official Bot 增加“启用 Markdown 渲染”配置开关，位于机器人创建/编辑页面的适配器配置表单中，默认关闭以保持原有兼
   容性。
 - 开启后，非流式 C2C 私聊和 QQ 群聊的文本回复将以 QQ Markdown 消息格式发送（msg_type: 2）。
 - 关闭或未配置该开关时，继续使用原有纯文本消息格式（msg_type: 0）。
 - 频道群聊和频道私信不受该开关影响，继续以纯文本发送；相关限制已在 WebUI 配置说明中标明。
 - 未修改 C2C 流式回复及富媒体消息逻辑。
 - 补充单元测试，覆盖 Markdown 请求体、开关的 C2C/群聊分流、默认纯文本兼容行为，以及频道消息不受开关影响的行为。
### 更改前后对比截图 / Screenshots

> 请在此部分粘贴更改前后对比截图（可以是界面截图、控制台输出、对话截图等）:  
> Please paste the screenshots of changes before and after here (can be interface screenshots, console output, conversation screenshots, etc.):
> 
> 修改前 / Before:
>
<img width="1920" height="928" alt="image" src="https://github.com/user-attachments/assets/89914c26-c696-42ce-9187-893e9080e54d" />
<img width="1614" height="799" alt="image" src="https://github.com/user-attachments/assets/552c137e-93e8-4d00-b2a0-05350efb50f6" />

> 修改后 / After:
`src/langbot/pkg/platform/sources/qqofficial.yaml`新增字段：
```yaml
    - name: enable-markdown-rendering
      label:
        en_US: Enable Markdown Rendering
        zh_Hans: 启用 Markdown 渲染
        zh_Hant: 啟用 Markdown 渲染
      description:
        en_US: Render non-stream C2C and QQ group text replies as Markdown. Channel messages always use plain text and are not affected by this setting.
        zh_Hans: 将非流式 C2C 私聊和 QQ 群聊文本回复渲染为 Markdown。频道消息始终以纯文本发送，不受此设置影响。
        zh_Hant: 將非串流 C2C 私聊與 QQ 群聊文字回覆渲染為 Markdown。頻道訊息一律以純文字傳送，不受此設定影響。
      type: boolean
      required: true
      default: false
```
> 图例为简体中文，提交中也包含英文和繁体中文
<img width="1920" height="930" alt="image" src="https://github.com/user-attachments/assets/b087c9c8-4b23-4c95-92a6-8a4d58477aa1" />
<img width="1609" height="799" alt="image" src="https://github.com/user-attachments/assets/5c51365a-160b-434d-adb9-70e3d37e789d" />


## 检查清单 / Checklist

### PR 作者完成 / For PR author

*请在方括号间写`x`以打勾 / Please tick the box with `x`*

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [x] 我已签署或将在机器人提示后签署 [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。 / I have signed, or will sign when prompted by the bot, the [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md).
- [x] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] 文档编写了吗？ / Have you written the documentation?