### PR TITLE
fix(auth): align invitation password fields

### DIFF
--- a/web/src/app/invitations/accept/page.tsx
+++ b/web/src/app/invitations/accept/page.tsx
@@ -386,15 +386,19 @@ export default function AcceptInvitationPage() {
                     >
                       {t('workspace.confirmPassword')}
                     </label>
-                    <Input
-                      id="invite-password-confirm"
-                      type="password"
-                      value={confirmPassword}
-                      onChange={(event) =>
-                        setConfirmPassword(event.target.value)
-                      }
-                      autoComplete="new-password"
-                    />
+                    <div className="relative">
+                      <Lock className="absolute left-3 top-3 size-4 text-muted-foreground" />
+                      <Input
+                        id="invite-password-confirm"
+                        type="password"
+                        value={confirmPassword}
+                        onChange={(event) =>
+                          setConfirmPassword(event.target.value)
+                        }
+                        className="pl-10"
+                        autoComplete="new-password"
+                      />
+                    </div>
                   </div>
                   <Button
                     className="w-full"
@@ -405,14 +409,6 @@ export default function AcceptInvitationPage() {
                       <Loader2 className="size-4 animate-spin" />
                     )}
                     {t('workspace.registerAndAccept')}
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    className="w-full"
-                    disabled={status === 'submitting'}
-                    onClick={() => navigate('/login?invitation=1')}
-                  >
-                    {t('workspace.alreadyHaveAccount')}
                   </Button>
                 </>
               ) : (

--- a/web/tests/e2e/invitations.spec.ts
+++ b/web/tests/e2e/invitations.spec.ts
@@ -93,7 +93,7 @@ test('login preserves an explicit invitation email mismatch error', async ({
   });
 
   await page.goto('/invitations/accept#token=mismatch-invitation');
-  await page.getByRole('button', { name: 'I already have an account' }).click();
+  await page.goto('/login?invitation=1');
   await page.getByPlaceholder('Enter email address').fill('other@example.com');
   await page.getByPlaceholder('Enter password').fill('password');
   await page.getByRole('button', { name: 'Login with password' }).click();
@@ -184,9 +184,19 @@ test('an OAuth-only OSS instance registers the invited email with a local passwo
   await expect(page.locator('#invite-email')).toHaveAttribute('readonly', '');
   await expect(page.locator('#invite-password')).toBeVisible();
   await expect(page.locator('#invite-password-confirm')).toBeVisible();
+  for (const inputId of ['invite-password', 'invite-password-confirm']) {
+    const input = page.locator(`#${inputId}`);
+    const field = input.locator('xpath=..');
+    await expect(field).toHaveClass(/relative/);
+    await expect(field.locator('svg')).toBeVisible();
+    await expect(input).toHaveClass(/pl-10/);
+  }
   await expect(
     page.getByRole('button', { name: 'Create account and accept' }),
   ).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'I already have an account' }),
+  ).toHaveCount(0);
   await expect(
     page.getByRole('button', { name: 'Login with LangBot Account' }),
   ).toHaveCount(0);


### PR DESCRIPTION
## Summary
- give both invitation password fields identical lock-icon and padding treatment
- remove the redundant “I already have an account” action from OSS invitation registration
- preserve the existing login mismatch regression path without exposing that action in the registration form

## Verification
- focused invitation/owner billing Playwright: 7 passed
- frontend unit tests: 34 passed
- ESLint: passed
- production build: passed