### PR TITLE
fix(monitoring): handle SQLite token statistics errors

### DIFF
--- a/src/langbot/pkg/persistence/tenant_uow.py
+++ b/src/langbot/pkg/persistence/tenant_uow.py
@@ -209,7 +209,7 @@ _ALLOWED_SCOPED_BUILTIN_FUNCTION_TYPES = {
     'now': sqlalchemy.sql.functions.now,
     'sum': sqlalchemy.sql.functions.sum,
 }
-_ALLOWED_SCOPED_GENERIC_FUNCTIONS = frozenset({'date_trunc', 'length', 'nullif'})
+_ALLOWED_SCOPED_GENERIC_FUNCTIONS = frozenset({'date_trunc', 'length', 'nullif', 'strftime'})
 _ALLOWED_SCOPED_CUSTOM_OPERATORS = frozenset({'<=>'})
 _ALLOWED_SCOPED_STATEMENT_TYPES = (
     sqlalchemy.sql.dml.UpdateBase,

--- a/tests/unit_tests/persistence/test_tenant_uow.py
+++ b/tests/unit_tests/persistence/test_tenant_uow.py
@@ -964,6 +964,7 @@ async def test_scoped_session_rejects_raw_or_unapproved_sql(
             sa.func.date_trunc('hour', sa.column('timestamp')),
             sa.func.length(sa.literal('value')),
             sa.func.nullif(sa.literal('value'), sa.literal('')),
+            sa.func.strftime('%Y-%m-%d %H:00', sa.column('timestamp')),
         ),
         sa.select(sa.column('embedding').op('<=>')(sa.literal([0.1]))),
         sa.select(sa.cast(sa.column('embedding'), Vector(384))),

--- a/web/src/app/home/monitoring/components/TokenMonitoring.tsx
+++ b/web/src/app/home/monitoring/components/TokenMonitoring.tsx
@@ -77,6 +77,14 @@ function formatNumber(n: number): string {
   return n.toLocaleString();
 }
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'object' && error !== null && 'msg' in error) {
+    return String((error as { msg?: unknown }).msg ?? '');
+  }
+  return String(error);
+}
+
 const TOOLTIP_STYLE: React.CSSProperties = {
   backgroundColor: 'var(--card)',
   border: '1px solid var(--border)',
@@ -152,7 +160,7 @@ export default function TokenMonitoring({
       });
       setStats(result);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setLoading(false);
     }

--- a/web/tests/unit/token-monitoring-error.test.mjs
+++ b/web/tests/unit/token-monitoring-error.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const source = fs.readFileSync(
+  path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../src/app/home/monitoring/components/TokenMonitoring.tsx',
+  ),
+  'utf8',
+);
+
+test('TokenMonitoring prefers the API error message for plain error objects', () => {
+  const helperStart = source.indexOf('function getErrorMessage');
+  const helperEnd = source.indexOf('\n}\n', helperStart) + 2;
+  const helper = source.slice(helperStart, helperEnd);
+
+  assert.ok(helperStart >= 0, 'TokenMonitoring error helper is missing');
+  assert.match(helper, /error instanceof Error/);
+  assert.match(helper, /typeof error === 'object'/);
+  assert.match(helper, /'msg' in error/);
+  assert.match(helper, /error as \{ msg\?: unknown \}/);
+  assert.match(source, /setError\(getErrorMessage\(e\)\)/);
+});


### PR DESCRIPTION
## Overview

Fixes #2468.

- allow the existing SQLite monitoring bucket query to use the safe `strftime` function;
- display the backend `msg` from plain API error objects instead of `[object Object]`;
- add focused backend and frontend regressions.

### Screenshots

No layout change. Error text changes from:

```text
[object Object]
```

to the backend-provided message.

## Validation

- `uv run pytest tests/unit_tests/persistence/test_tenant_uow.py -q --tb=short --capture=no` — 117 passed
- `uv run ruff check` and `uv run ruff format --check` on changed Python files
- `node --test tests/unit/*.test.mjs` — 35 passed
- `pnpm exec tsc --noEmit`
- `pnpm lint` — 0 errors
- `pnpm build`
- `git diff --check`

## Checklist

- [x] Read the contribution guide
- [x] I have signed, or will sign when prompted by the CLA bot
- [x] Communicated with the maintainer in https://github.com/langbot-app/LangBot/issues/2468#issuecomment-5414378217
- [x] Tested the change locally
