### PR TITLE
fix(provider): tolerate trimmed image parts in litellm message conversion

### DIFF
--- a/src/langbot/pkg/provider/modelmgr/requesters/litellmchat.py
+++ b/src/langbot/pkg/provider/modelmgr/requesters/litellmchat.py
@@ -747,9 +747,24 @@ class LiteLLMRequester(requester.ProviderAPIRequester):
                 converted_parts = []
                 for part in content:
                     if isinstance(part, dict) and part.get('type') == 'image_base64':
-                        part['image_url'] = {'url': part['image_base64']}
-                        part['type'] = 'image_url'
-                        del part['image_base64']
+                        # History trimming (SessionManager) clears image_base64
+                        # on past turns and exclude_none serialization drops
+                        # the key entirely, so the replayed part may carry no
+                        # payload. Prefer the base64 payload; fall back to an
+                        # image_url that survived on the same element; drop
+                        # hollow parts instead of raising KeyError (#2469).
+                        image_b64 = part.get('image_base64')
+                        fallback_url = None
+                        if not image_b64:
+                            raw_image_url = part.get('image_url')
+                            if isinstance(raw_image_url, dict):
+                                fallback_url = raw_image_url.get('url')
+                        if image_b64 or fallback_url:
+                            part['image_url'] = {'url': image_b64 or fallback_url}
+                            part['type'] = 'image_url'
+                            part.pop('image_base64', None)
+                        else:
+                            continue
                     # OpenAI-compatible chat models reject non-image file parts
                     # (audio/document base64 or url). These originate from Voice /
                     # File attachments — including ones replayed from conversation

--- a/tests/unit_tests/provider/test_litellm_convert_messages.py
+++ b/tests/unit_tests/provider/test_litellm_convert_messages.py
@@ -91,3 +91,42 @@ def test_convert_messages_plain_string_content_untouched():
     msg = provider_message.Message(role='user', content='just text')
     out = req._convert_messages([msg])
     assert out[0]['content'] == 'just text'
+
+
+def test_convert_messages_replayed_image_without_base64_does_not_crash():
+    """Replayed image parts hollowed out by history trimming must not raise KeyError (#2469).
+
+    SessionManager clears image_base64 on past turns, and URL-less platform
+    images never had a URL, so the replayed part serializes as
+    {'type': 'image_base64'} with no payload keys. The hollow part should be
+    dropped while the sibling text part survives.
+    """
+    req = _make_requester()
+    image = provider_message.ContentElement.from_image_base64('data:image/jpeg;base64,AAAA')
+    # Simulate SessionManager.trim_conversation_messages clearing binary payloads.
+    image.image_base64 = None
+    msg = provider_message.Message(
+        role='user',
+        content=[
+            provider_message.ContentElement.from_text('describe the photo'),
+            image,
+        ],
+    )
+    out = req._convert_messages([msg])
+    assert [p.get('type') for p in out[0]['content']] == ['text']
+
+
+def test_convert_messages_replayed_image_with_url_falls_back_to_url():
+    """When base64 was trimmed but image_url survived, rebuild the OpenAI image_url part from the URL."""
+    req = _make_requester()
+    image = provider_message.ContentElement(
+        type='image_base64',
+        image_base64=None,
+        image_url=provider_message.ImageURLContentObject(url='https://example.com/pic.jpg'),
+    )
+    msg = provider_message.Message(role='user', content=[image])
+    out = req._convert_messages([msg])
+    parts = out[0]['content']
+    assert [p.get('type') for p in parts] == ['image_url']
+    assert parts[0]['image_url'] == {'url': 'https://example.com/pic.jpg'}
+    assert 'image_base64' not in parts[0]


### PR DESCRIPTION
Fixes #2469.

## 概述 / Overview

`LiteLLMRequester._convert_messages` 在重放历史消息时对 `image_base64` 类型的图片 part 无条件执行 `part['image_base64']`，而会话历史裁剪（`SessionManager.trim_conversation_messages`）会把历史里的 `image_base64` 置空以节省内存，`exclude_none` 序列化又直接丢掉该字段。于是发过图片之后的每一轮对话都会在重放历史时抛出 `KeyError: 'image_base64'`，模型 fallback 全部失败，`pipelinemgr` 把异常文本直接回显给用户。

修复策略与已有的 file part 丢弃逻辑保持一致：

- 有 `image_base64` 时行为不变（转换为 `image_url`）；
- base64 被裁但同 element 上 `image_url` 幸存时，回退用 URL 构造 `image_url` part；
- 两者皆空的空壳 part 直接丢弃，不再崩溃。

### 更改前后对比 / Before & After

修改前（发图后下一轮对话，日志逐字复现 issue）：

```text
KeyError: 'image_base64'
```

修改后：空壳图片 part 被安全丢弃，同轮文本正常发送，后续对话恢复正常。

## 验证 / Verification

- 新增回归测试 2 个，修复前均以 `KeyError: 'image_base64'` 失败，修复后通过：
  - `tests/unit_tests/provider/test_litellm_convert_messages.py::test_convert_messages_replayed_image_without_base64_does_not_crash`
  - `tests/unit_tests/provider/test_litellm_convert_messages.py::test_convert_messages_replayed_image_with_url_falls_back_to_url`
- `uv run pytest tests/unit_tests/provider/test_litellm_convert_messages.py tests/unit_tests/provider/test_litellmchat.py -q` — 69 passed
- `uv run pytest tests/unit_tests/provider -q` — 482 passed
- `uv run pytest tests/unit_tests -q` — 2798 passed, 1 skipped
- `uv run ruff check` / `ruff format --check` — 通过

## 检查清单 / Checklist

### PR 作者完成 / For PR author

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the contribution guide?
- [x] 我已签署或将在机器人提示后签署 [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。 / I have signed, or will sign when prompted by the bot, the CLA.
- [x] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer? (issue #2469 内已含完整根因分析，本 PR 按其结论修复)
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [x] 相关 issues 链接了吗？ / Have you linked the related issues? — #2469
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect? — 不涉及
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py? — 不涉及
- [ ] 文档编写了吗？ / Have you written the documentation? — 不涉及