### PR TITLE
fix(provider): stringify MCP tool results for OpenAI-compatible APIs

### DIFF
--- a/src/langbot/pkg/provider/runners/localagent.py
+++ b/src/langbot/pkg/provider/runners/localagent.py
@@ -619,7 +619,9 @@ class LocalAgentRunner(runner.RequestRunner):
                         and len(func_ret) > 0
                         and isinstance(func_ret[0], provider_message.ContentElement)
                     ):
-                        tool_content = func_ret
+                        # OpenAI-compatible APIs require tool-message content to be a
+                        # string; a raw list of ContentElement causes HTTP 500 (#2457).
+                        tool_content = '\n'.join(str(ce) for ce in func_ret)
                     else:
                         tool_content = json.dumps(func_ret, ensure_ascii=False)
 

--- a/tests/unit_tests/provider/test_localagent_tool_content.py
+++ b/tests/unit_tests/provider/test_localagent_tool_content.py
@@ -1,0 +1,208 @@
+"""Regression tests for tool-message content serialization (#2457).
+
+MCP tools return ``list[ContentElement]`` from ``execute_func_call``.
+The runner must serialize that list to a string before placing it in a
+``role='tool'`` message, because the OpenAI chat-completions spec
+requires tool-message content to be a string. Sending the raw list
+causes OpenAI-compatible endpoints to return HTTP 500.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+import langbot_plugin.api.entities.builtin.pipeline.query as pipeline_query
+import langbot_plugin.api.entities.builtin.provider.message as provider_message
+import langbot_plugin.api.entities.builtin.provider.session as provider_session
+
+from langbot.pkg.api.http.context import ExecutionContext, PrincipalContext, PrincipalType
+from langbot.pkg.provider.runners.localagent import LocalAgentRunner
+
+
+class _ToolCallProvider:
+    """Non-streaming provider: round 1 issues a tool call, round 2 returns text."""
+
+    def __init__(self):
+        self.requests: list[dict] = []
+
+    async def invoke_llm(self, query, model, messages, funcs, extra_args=None, remove_think=None):
+        self.requests.append({'messages': list(messages)})
+
+        if len(self.requests) == 1:
+            return provider_message.Message(
+                role='assistant',
+                content='Let me search that.',
+                tool_calls=[
+                    provider_message.ToolCall(
+                        id='call-mcp-1',
+                        type='function',
+                        function=provider_message.FunctionCall(
+                            name='duckduckgo_search',
+                            arguments=json.dumps({'query': 'swift'}),
+                        ),
+                    )
+                ],
+            )
+
+        return provider_message.Message(role='assistant', content='Done.')
+
+
+class _ToolCallStreamProvider:
+    """Streaming variant of _ToolCallProvider."""
+
+    def __init__(self):
+        self.requests: list[dict] = []
+
+    def invoke_llm_stream(self, query, model, messages, funcs, extra_args=None, remove_think=None):
+        self.requests.append({'messages': list(messages)})
+
+        async def _stream():
+            if len(self.requests) == 1:
+                yield provider_message.MessageChunk(
+                    role='assistant',
+                    content='Let me search that.',
+                    tool_calls=[
+                        provider_message.ToolCall(
+                            id='call-mcp-1',
+                            type='function',
+                            function=provider_message.FunctionCall(
+                                name='duckduckgo_search',
+                                arguments=json.dumps({'query': 'swift'}),
+                            ),
+                        )
+                    ],
+                    is_final=True,
+                )
+                return
+
+            yield provider_message.MessageChunk(
+                role='assistant',
+                content='Done.',
+                is_final=True,
+            )
+
+        return _stream()
+
+
+def _make_query(stream: bool = False) -> pipeline_query.Query:
+    adapter = AsyncMock()
+    adapter.is_stream_output_supported = AsyncMock(return_value=stream)
+
+    query = pipeline_query.Query.model_construct(
+        query_id='mcp-tool-query',
+        launcher_type=provider_session.LauncherTypes.PERSON,
+        launcher_id=12345,
+        sender_id=12345,
+        message_chain=[],
+        message_event=None,
+        adapter=adapter,
+        pipeline_uuid='pipeline-uuid',
+        bot_uuid='bot-uuid',
+        pipeline_config={
+            'ai': {
+                'runner': {'runner': 'local-agent'},
+                'local-agent': {'model': {'primary': 'test-model-uuid', 'fallbacks': []}, 'prompt': 'test-prompt'},
+            },
+            'output': {'misc': {'remove-think': False}},
+        },
+        prompt=SimpleNamespace(messages=[]),
+        messages=[],
+        user_message=provider_message.Message(role='user', content='search swift'),
+        use_funcs=[SimpleNamespace(name='duckduckgo_search')],
+        use_llm_model_uuid='test-model-uuid',
+        variables={},
+    )
+    object.__setattr__(
+        query,
+        '_execution_context',
+        ExecutionContext(
+            instance_uuid='instance-test',
+            workspace_uuid='workspace-test',
+            placement_generation=1,
+            trigger_principal=PrincipalContext(PrincipalType.SYSTEM),
+        ),
+    )
+    return query
+
+
+def _make_app(provider, func_ret) -> SimpleNamespace:
+    """Build a minimal app whose tool_mgr returns *func_ret*."""
+    model = SimpleNamespace(
+        provider=provider,
+        model_entity=SimpleNamespace(
+            uuid='test-model-uuid',
+            name='test-model',
+            abilities=['func_call'],
+            extra_args={},
+        ),
+    )
+    return SimpleNamespace(
+        logger=Mock(),
+        model_mgr=SimpleNamespace(get_model_by_uuid=AsyncMock(return_value=model)),
+        tool_mgr=SimpleNamespace(execute_func_call=AsyncMock(return_value=func_ret)),
+        rag_mgr=SimpleNamespace(),
+        box_service=SimpleNamespace(get_system_guidance=Mock(return_value='sandbox guidance')),
+        skill_mgr=SimpleNamespace(
+            get_skills_for_pipeline=AsyncMock(return_value=[]),
+            detect_skill_activation=AsyncMock(return_value=None),
+            build_activation_prompt=Mock(return_value=None),
+        ),
+    )
+
+
+# The actual shape returned by MCP tools: a list of ContentElement objects.
+_MCP_FUNC_RET = [
+    provider_message.ContentElement.from_text('Title: Swift - Wikipedia\nURL: https://en.wikipedia.org/wiki/Swift'),
+    provider_message.ContentElement.from_text('Title: Swift Programming Language\nURL: https://swift.org'),
+]
+
+
+@pytest.mark.asyncio
+async def test_tool_message_content_is_string_not_list():
+    """Non-streaming: tool message content must be a string (#2457).
+
+    Before the fix, ``func_ret`` (a ``list[ContentElement]``) was assigned
+    to ``tool_content`` as-is, so the tool message carried a list instead
+    of a string, causing OpenAI-compatible APIs to return 500.
+    """
+    provider = _ToolCallProvider()
+    app = _make_app(provider, _MCP_FUNC_RET)
+    runner = LocalAgentRunner(app, pipeline_config={})
+    query = _make_query(stream=False)
+
+    results = [msg async for msg in runner.run(query)]
+
+    tool_msgs = [m for m in results if m.role == 'tool']
+    assert len(tool_msgs) == 1
+
+    # The content must be a string, not a list.
+    assert isinstance(tool_msgs[0].content, str), (
+        f'tool message content should be str, got {type(tool_msgs[0].content).__name__}'
+    )
+    # And it should contain the text of both ContentElements.
+    assert 'Swift - Wikipedia' in tool_msgs[0].content
+    assert 'Swift Programming Language' in tool_msgs[0].content
+
+
+@pytest.mark.asyncio
+async def test_tool_message_content_is_string_in_stream():
+    """Streaming: same regression check for the streaming path (#2457)."""
+    provider = _ToolCallStreamProvider()
+    app = _make_app(provider, _MCP_FUNC_RET)
+    runner = LocalAgentRunner(app, pipeline_config={})
+    query = _make_query(stream=True)
+
+    results = [msg async for msg in runner.run(query)]
+
+    tool_msgs = [m for m in results if m.role == 'tool']
+    assert len(tool_msgs) == 1
+
+    assert isinstance(tool_msgs[0].content, str), (
+        f'tool message content should be str, got {type(tool_msgs[0].content).__name__}'
+    )
+    assert 'Swift - Wikipedia' in tool_msgs[0].content
+    assert 'Swift Programming Language' in tool_msgs[0].content


### PR DESCRIPTION
Fixes #2457.

## 概述 / Overview

`LocalAgentRunner` 的 tool-call 循环中，`execute_func_call` 对 MCP 工具返回 `list[ContentElement]`，runner 直接将这个列表赋给 `role='tool'` 消息的 `content`。但 OpenAI chat-completions 规范要求 tool 消息 content 为字符串，OpenAI 兼容端点收到数组后返回 HTTP 500。

修复：将 `list[ContentElement]` 序列化为字符串后再赋给 tool 消息 content。利用 `ContentElement.__str__`：text 类型返回实际文本内容，图片/文件类型返回可读占位符。

### 更改前后对比 / Before & After

修改前（调用 MCP 工具后，OpenAI 兼容 API 返回 500）：

```text
litellm.InternalServerError: InternalServerError: OpenAIException - openai_error
```

修改后：tool 消息 content 为字符串，API 正常返回 200。

## 验证 / Verification

- 新增回归测试 2 个，修复前均失败（content 为 `list` 而非 `str`），修复后通过：
  - `tests/unit_tests/provider/test_localagent_tool_content.py::test_tool_message_content_is_string_not_list`
  - `tests/unit_tests/provider/test_localagent_tool_content.py::test_tool_message_content_is_string_in_stream`
- `uv run pytest tests/unit_tests/provider -q` — 484 passed
- `uv run pytest tests/unit_tests -q` — 2800 passed, 1 skipped
- `uv run ruff check` / `ruff format --check` — 通过

## 检查清单 / Checklist

### PR 作者完成 / For PR author

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the contribution guide?
- [x] 我已签署或将在机器人提示后签署 [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。 / I have signed, or will sign when prompted by the bot, the CLA.
- [x] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer? (issue #2457 内已有维护者确认 PR welcomed)
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [x] 相关 issues 链接了吗？ / Have you linked the related issues? — #2457
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect? — 不涉及
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py? — 不涉及
- [ ] 文档编写了吗？ / Have you written the documentation? — 不涉及