### PR TITLE
fix(security): harden recovery key entropy and reset-password brute-force protection

### DIFF
--- a/src/langbot/pkg/api/http/controller/groups/user.py
+++ b/src/langbot/pkg/api/http/controller/groups/user.py
@@ -2,6 +2,8 @@ import quart
 import argon2
 import asyncio
 import datetime
+import hmac
+import time
 import uuid
 from urllib.parse import parse_qs, urlsplit
 
@@ -10,6 +12,16 @@ from .....entity.errors import account as account_errors
 from ...context import RequestContext
 from .....cloud.launch import SpaceLaunchError
 from ...service.user import ControlPlaneDirectoryRequiredError, PublicRegistrationClosedError
+
+# Brute-force protection for the unauthenticated reset-password endpoint (#2392).
+# After _MAX_RECOVERY_KEY_FAILURES wrong recovery keys the endpoint rejects every
+# attempt (even with a correct key) for _RECOVERY_KEY_LOCKOUT_SECONDS. The legacy
+# fixed asyncio.sleep(3) did not throttle concurrent requests, allowing the 24-bit
+# legacy keyspace to be exhausted in hours.
+_MAX_RECOVERY_KEY_FAILURES = 5
+_RECOVERY_KEY_LOCKOUT_SECONDS = 15 * 60
+
+_recovery_key_state: dict = {'failures': 0, 'locked_until': 0.0}
 
 
 @group.group_class('user', '/api/v1/user')
@@ -87,6 +99,10 @@ class UserRouterGroup(group.RouterGroup):
             recovery_key = json_data['recovery_key']
             new_password = json_data['new_password']
 
+            # Reject while locked out, before any sleep or service call (#2392)
+            if time.monotonic() < _recovery_key_state['locked_until']:
+                return self.http_status(429, -1, 'Too many failed attempts, try again later')
+
             # hard sleep 3s for security
             await asyncio.sleep(3)
 
@@ -98,9 +114,21 @@ class UserRouterGroup(group.RouterGroup):
             if user_obj is None:
                 return self.http_status(400, -1, 'User not found')
 
-            if recovery_key != self.ap.instance_config.data['system']['recovery_key']:
+            stored_key = self.ap.instance_config.data['system']['recovery_key']
+            key_matches = (
+                isinstance(recovery_key, str)
+                and isinstance(stored_key, str)
+                and hmac.compare_digest(recovery_key.encode(), stored_key.encode())
+            )
+
+            if not key_matches:
+                _recovery_key_state['failures'] += 1
+                if _recovery_key_state['failures'] >= _MAX_RECOVERY_KEY_FAILURES:
+                    _recovery_key_state['locked_until'] = time.monotonic() + _RECOVERY_KEY_LOCKOUT_SECONDS
+                    _recovery_key_state['failures'] = 0
                 return self.http_status(403, -1, 'Invalid recovery key')
 
+            _recovery_key_state['failures'] = 0
             await self.ap.user_service.reset_password(user_email, new_password)
 
             return self.success(data={'user': user_email})

--- a/src/langbot/pkg/api/http/controller/groups/user.py
+++ b/src/langbot/pkg/api/http/controller/groups/user.py
@@ -13,15 +13,32 @@ from ...context import RequestContext
 from .....cloud.launch import SpaceLaunchError
 from ...service.user import ControlPlaneDirectoryRequiredError, PublicRegistrationClosedError
 
-# Brute-force protection for the unauthenticated reset-password endpoint (#2392).
-# After _MAX_RECOVERY_KEY_FAILURES wrong recovery keys the endpoint rejects every
-# attempt (even with a correct key) for _RECOVERY_KEY_LOCKOUT_SECONDS. The legacy
-# fixed asyncio.sleep(3) did not throttle concurrent requests, allowing the 24-bit
-# legacy keyspace to be exhausted in hours.
-_MAX_RECOVERY_KEY_FAILURES = 5
-_RECOVERY_KEY_LOCKOUT_SECONDS = 15 * 60
+# Fixed-window admission quota for the unauthenticated reset-password endpoint (#2392).
+# The admission check and slot bump share ONE synchronous critical section with no await
+# points, so concurrent bursts within a single event loop cannot slip past accounting.
+# Every admitted attempt consumes quota (regardless of success), which throttles both the
+# legacy 24-bit keyspace exhaustion and brute-force on modern high-entropy keys.
+# NOTE: this state is process-local; multi-worker deployments need a shared limiter upstream.
+_MAX_RESET_ATTEMPTS_PER_WINDOW = 5
+_RESET_WINDOW_SECONDS = 15 * 60
 
-_recovery_key_state: dict = {'failures': 0, 'locked_until': 0.0}
+_reset_password_state: dict = {'window_started_at': 0.0, 'attempts': 0}
+
+
+def _admit_reset_attempt(now: float) -> bool:
+    """Atomically reserve one reset-password admission slot.
+
+    Must stay await-free: running to completion without suspension makes the
+    check-and-increment atomic under the single-threaded event loop.
+    """
+    st = _reset_password_state
+    if now - st['window_started_at'] >= _RESET_WINDOW_SECONDS:
+        st['window_started_at'] = now
+        st['attempts'] = 0
+    if st['attempts'] >= _MAX_RESET_ATTEMPTS_PER_WINDOW:
+        return False
+    st['attempts'] += 1
+    return True
 
 
 @group.group_class('user', '/api/v1/user')
@@ -93,15 +110,17 @@ class UserRouterGroup(group.RouterGroup):
 
         @self.route('/reset-password', methods=['POST'], auth_type=group.AuthType.NONE)
         async def _() -> str:
+            # Admit (or reject) BEFORE touching the body or any service call (#2392):
+            # rejecting requests never reach the slow path, and quota accounting happens
+            # synchronously at entry, closing the post-await race of burst requests.
+            if not _admit_reset_attempt(time.monotonic()):
+                return self.http_status(429, -1, 'Too many attempts, try again later')
+
             json_data = await quart.request.json
 
             user_email = json_data['user']
             recovery_key = json_data['recovery_key']
             new_password = json_data['new_password']
-
-            # Reject while locked out, before any sleep or service call (#2392)
-            if time.monotonic() < _recovery_key_state['locked_until']:
-                return self.http_status(429, -1, 'Too many failed attempts, try again later')
 
             # hard sleep 3s for security
             await asyncio.sleep(3)
@@ -122,13 +141,8 @@ class UserRouterGroup(group.RouterGroup):
             )
 
             if not key_matches:
-                _recovery_key_state['failures'] += 1
-                if _recovery_key_state['failures'] >= _MAX_RECOVERY_KEY_FAILURES:
-                    _recovery_key_state['locked_until'] = time.monotonic() + _RECOVERY_KEY_LOCKOUT_SECONDS
-                    _recovery_key_state['failures'] = 0
                 return self.http_status(403, -1, 'Invalid recovery key')
 
-            _recovery_key_state['failures'] = 0
             await self.ap.user_service.reset_password(user_email, new_password)
 
             return self.success(data={'user': user_email})

--- a/src/langbot/pkg/api/http/controller/groups/user.py
+++ b/src/langbot/pkg/api/http/controller/groups/user.py
@@ -134,11 +134,15 @@ class UserRouterGroup(group.RouterGroup):
                 return self.http_status(400, -1, 'User not found')
 
             stored_key = self.ap.instance_config.data['system']['recovery_key']
-            key_matches = (
-                isinstance(recovery_key, str)
-                and isinstance(stored_key, str)
-                and hmac.compare_digest(recovery_key.encode(), stored_key.encode())
-            )
+            try:
+                key_matches = (
+                    isinstance(recovery_key, str)
+                    and isinstance(stored_key, str)
+                    and hmac.compare_digest(recovery_key.encode(), stored_key.encode())
+                )
+            except UnicodeEncodeError:
+                # JSON can contain lone surrogates, which are not valid UTF-8.
+                key_matches = False
 
             if not key_matches:
                 return self.http_status(403, -1, 'Invalid recovery key')

--- a/src/langbot/pkg/core/stages/genkeys.py
+++ b/src/langbot/pkg/core/stages/genkeys.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import logging
 import secrets
 
 from .. import stage, app
+
+# This stage runs before SetupLoggerStage, so ap.logger is still None here;
+# the module logger falls back to the stderr lastResort handler.
+_logger = logging.getLogger(__name__)
 
 
 @stage.stage_class('GenKeysStage')
@@ -20,5 +25,13 @@ class GenKeysStage(stage.BootingStage):
             ap.instance_config.data['system']['recovery_key'] = ''
 
         if not ap.instance_config.data['system']['recovery_key']:
-            ap.instance_config.data['system']['recovery_key'] = secrets.token_hex(3).upper()
+            # 256-bit key, aligned with the API key strength; the legacy 24-bit
+            # key (token_hex(3)) was brute-forceable within hours (#2392).
+            ap.instance_config.data['system']['recovery_key'] = secrets.token_urlsafe(32)
             await ap.instance_config.dump_config()
+        elif len(ap.instance_config.data['system']['recovery_key']) < 16:
+            _logger.warning(
+                'Low-entropy legacy recovery key detected (length < 16); '
+                'regenerate system.recovery_key in the configuration file '
+                'with a strong random value (#2392)'
+            )

--- a/src/langbot/pkg/core/stages/genkeys.py
+++ b/src/langbot/pkg/core/stages/genkeys.py
@@ -9,6 +9,10 @@ from .. import stage, app
 # the module logger falls back to the stderr lastResort handler.
 _logger = logging.getLogger(__name__)
 
+# 32 symbols without 0/O or 1/I; eight independent draws provide 40 random bits.
+_RECOVERY_KEY_ALPHABET = '23456789ABCDEFGHJKLMNPQRSTUVWXYZ'
+_RECOVERY_KEY_LENGTH = 8
+
 
 @stage.stage_class('GenKeysStage')
 class GenKeysStage(stage.BootingStage):
@@ -25,13 +29,15 @@ class GenKeysStage(stage.BootingStage):
             ap.instance_config.data['system']['recovery_key'] = ''
 
         if not ap.instance_config.data['system']['recovery_key']:
-            # 256-bit key, aligned with the API key strength; the legacy 24-bit
-            # key (token_hex(3)) was brute-forceable within hours (#2392).
-            ap.instance_config.data['system']['recovery_key'] = secrets.token_urlsafe(32)
+            # Keep recovery practical to type. Security also requires the reset
+            # endpoint's concurrency-safe quota (five admissions per 15 minutes).
+            ap.instance_config.data['system']['recovery_key'] = ''.join(
+                secrets.choice(_RECOVERY_KEY_ALPHABET) for _ in range(_RECOVERY_KEY_LENGTH)
+            )
             await ap.instance_config.dump_config()
-        elif len(ap.instance_config.data['system']['recovery_key']) < 16:
+        elif len(ap.instance_config.data['system']['recovery_key']) < _RECOVERY_KEY_LENGTH:
             _logger.warning(
-                'Low-entropy legacy recovery key detected (length < 16); '
+                'Low-entropy legacy recovery key detected (length < 8); '
                 'regenerate system.recovery_key in the configuration file '
                 'with a strong random value (#2392)'
             )

--- a/tests/integration/api/test_recovery_password_journey.py
+++ b/tests/integration/api/test_recovery_password_journey.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from quart import Quart
+
+from langbot.pkg.api.http.controller.groups import user as user_module
+from langbot.pkg.api.http.controller.groups.user import UserRouterGroup
+from langbot.pkg.api.http.service.user import UserService
+from langbot.pkg.core.stages.genkeys import GenKeysStage
+from langbot.pkg.persistence.mgr import PersistenceManager
+from langbot.pkg.utils import constants
+from langbot.pkg.workspace.collaboration import WorkspaceCollaborationService
+from langbot.pkg.workspace.service import WorkspaceService
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+async def test_generated_recovery_code_resets_real_sqlite_account(tmp_path, monkeypatch):
+    """Exercise generation, reset, and old/new password login without mocked user services."""
+    monkeypatch.setattr(constants, 'instance_id', 'recovery-journey')
+    monkeypatch.setattr(user_module, '_reset_password_state', {'window_started_at': 0.0, 'attempts': 0})
+    monkeypatch.setattr(user_module, 'asyncio', SimpleNamespace(sleep=AsyncMock()))
+    application = SimpleNamespace(
+        logger=logging.getLogger('recovery-password-journey'),
+        instance_config=SimpleNamespace(
+            data={
+                'database': {'use': 'sqlite', 'sqlite': {'path': str(tmp_path / 'recovery.db')}},
+                'system': {
+                    'jwt': {'secret': 'recovery-journey-test-secret-only', 'expire': 3600},
+                    'recovery_key': '',
+                },
+            },
+            dump_config=AsyncMock(),
+        ),
+    )
+    await GenKeysStage().run(application)
+    key = application.instance_config.data['system']['recovery_key']
+    assert len(key) == 8
+    assert set(key) <= set('23456789ABCDEFGHJKLMNPQRSTUVWXYZ')
+    persistence = PersistenceManager(application)
+    application.persistence_mgr = persistence
+    try:
+        await persistence.initialize()
+        application.workspace_service = WorkspaceService(application, instance_uuid='recovery-journey')
+        application.workspace_collaboration_service = WorkspaceCollaborationService(
+            application, application.workspace_service
+        )
+        application.user_service = UserService(application)
+        quart_app = Quart(__name__)
+        await UserRouterGroup(application, quart_app).initialize()
+        client = quart_app.test_client()
+
+        initial = await client.post(
+            '/api/v1/user/init', json={'user': 'owner@example.com', 'password': 'OriginalPass1!'}
+        )
+        assert initial.status_code == 200
+        assert (await initial.get_json())['code'] == 0
+
+        payload = {'user': 'owner@example.com', 'recovery_key': 'WRONG', 'new_password': 'RecoveredPass1!'}
+        wrong = await client.post('/api/v1/user/reset-password', json=payload)
+        assert wrong.status_code == 403
+        unchanged = await client.post(
+            '/api/v1/user/auth', json={'user': 'owner@example.com', 'password': 'OriginalPass1!'}
+        )
+        assert (await unchanged.get_json())['code'] == 0
+
+        reset = await client.post('/api/v1/user/reset-password', json={**payload, 'recovery_key': key})
+        assert reset.status_code == 200
+        assert (await reset.get_json())['code'] == 0
+        old_login = await client.post(
+            '/api/v1/user/auth', json={'user': 'owner@example.com', 'password': 'OriginalPass1!'}
+        )
+        assert (await old_login.get_json())['code'] != 0
+        new_login = await client.post(
+            '/api/v1/user/auth', json={'user': 'owner@example.com', 'password': 'RecoveredPass1!'}
+        )
+        new_data = await new_login.get_json()
+        assert new_data['code'] == 0
+        assert new_data['data']['token']
+    finally:
+        await persistence.get_db_engine().dispose()

--- a/tests/unit_tests/api/test_user_reset_password.py
+++ b/tests/unit_tests/api/test_user_reset_password.py
@@ -1,0 +1,246 @@
+"""Regression tests for recovery-key hardening (#2392).
+
+Covers two attack surfaces reported in GHSA-4xcp-6758-rxqv:
+
+1. ``genkeys.py`` generated ``system.recovery_key`` with only 24 bits of
+   entropy (``secrets.token_hex(3)``), making the whole keyspace brute-forceable.
+2. ``POST /api/v1/user/reset-password`` (unauthenticated) had no lockout, so
+   concurrent guesses bypassed its fixed ``asyncio.sleep(3)`` delay, and the
+   key comparison used ``!=`` instead of a constant-time comparison.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import quart
+
+from langbot.pkg.api.http.controller.groups import user as user_module
+from langbot.pkg.api.http.controller.groups.user import UserRouterGroup
+from langbot.pkg.core.stages.genkeys import GenKeysStage
+
+pytestmark = pytest.mark.asyncio
+
+STORED_KEY = 'Rk9SX1RFU1RfUkVDT1ZFUllfS0VZXzEyMzQ1Njc4OTA='
+
+
+@pytest.fixture(autouse=True)
+def _reset_lockout_state():
+    """Reset the module-level failure counter before each test."""
+    user_module._recovery_key_state['failures'] = 0
+    user_module._recovery_key_state['locked_until'] = 0.0
+    yield
+    user_module._recovery_key_state['failures'] = 0
+    user_module._recovery_key_state['locked_until'] = 0.0
+
+
+@pytest.fixture(autouse=True)
+def _fast_sleep(monkeypatch):
+    """Neutralize the fixed 3s delay so tests run instantly."""
+    monkeypatch.setattr(user_module, 'asyncio', SimpleNamespace(sleep=AsyncMock()))
+
+
+# ---------------------------------------------------------------------------
+# genkeys.py: recovery-key entropy
+# ---------------------------------------------------------------------------
+
+
+def _make_genkeys_ap(existing_key: str) -> SimpleNamespace:
+    """Build a minimal Application mock for GenKeysStage.
+
+    Mirrors the real boot order: no ``logger`` attribute is set because
+    GenKeysStage runs before SetupLoggerStage.
+    """
+    return SimpleNamespace(
+        instance_config=SimpleNamespace(
+            data={'system': {'jwt': {'secret': 'jwt-secret'}, 'recovery_key': existing_key}},
+            dump_config=AsyncMock(),
+        ),
+    )
+
+
+async def test_recovery_key_generation_uses_high_entropy():
+    """Newly generated recovery keys must carry at least 256 bits (#2392).
+
+    The legacy generator produced 6 hex chars (24 bits); the keyspace was
+    exhaustible within hours. The replacement must be at least 32 chars.
+    """
+    ap = _make_genkeys_ap(existing_key='')
+
+    await GenKeysStage().run(ap)
+
+    key = ap.instance_config.data['system']['recovery_key']
+    assert len(key) >= 32, f'recovery key has only {len(key)} chars'
+    assert ap.instance_config.dump_config.called
+
+
+async def test_legacy_low_entropy_key_preserved_with_warning(caplog):
+    """A legacy 6-char key must keep working but emit a warning, without ap.logger."""
+    ap = _make_genkeys_ap(existing_key='ABC123')
+
+    with caplog.at_level(logging.WARNING, logger='langbot.pkg.core.stages.genkeys'):
+        await GenKeysStage().run(ap)
+
+    assert ap.instance_config.data['system']['recovery_key'] == 'ABC123'
+    assert any('Low-entropy' in record.message for record in caplog.records)
+    assert not ap.instance_config.dump_config.called
+
+
+async def test_recovery_key_generation_preserves_existing_key():
+    """An explicitly configured recovery key must not be regenerated on boot."""
+    ap = _make_genkeys_ap(existing_key='my-own-strong-recovery-key-0123456789')
+
+    await GenKeysStage().run(ap)
+
+    assert ap.instance_config.data['system']['recovery_key'] == 'my-own-strong-recovery-key-0123456789'
+    assert not ap.instance_config.dump_config.called
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/user/reset-password: lockout + constant-time compare
+# ---------------------------------------------------------------------------
+
+
+async def _create_client():
+    """Create a Quart test client with a mocked Application."""
+    quart_app = quart.Quart(__name__)
+
+    user_obj = SimpleNamespace(uuid='user-uuid', user='admin@example.com')
+    reset_password = AsyncMock()
+    get_user_by_email = AsyncMock(return_value=user_obj)
+
+    ap = SimpleNamespace(
+        user_service=SimpleNamespace(
+            is_initialized=AsyncMock(return_value=True),
+            get_user_by_email=get_user_by_email,
+            reset_password=reset_password,
+        ),
+        instance_config=SimpleNamespace(
+            data={'system': {'recovery_key': STORED_KEY}},
+        ),
+    )
+
+    router = UserRouterGroup(ap, quart_app)
+    await router.initialize()
+
+    client = quart_app.test_client()
+    return client, reset_password, get_user_by_email
+
+
+def _payload(key: str = STORED_KEY) -> dict:
+    return {'user': 'admin@example.com', 'recovery_key': key, 'new_password': 'NewPass1!'}
+
+
+async def test_correct_key_resets_password():
+    """A correct recovery key resets the password and returns success."""
+    client, reset_password, _ = await _create_client()
+
+    resp = await client.post('/api/v1/user/reset-password', json=_payload())
+
+    assert resp.status_code == 200
+    assert (await resp.get_json())['code'] == 0
+    reset_password.assert_awaited_once_with('admin@example.com', 'NewPass1!')
+
+
+async def test_wrong_key_rejected_without_reset():
+    """A wrong recovery key returns 403 and never touches the password."""
+    client, reset_password, _ = await _create_client()
+
+    resp = await client.post('/api/v1/user/reset-password', json=_payload(key='WRONG'))
+
+    assert resp.status_code == 403
+    reset_password.assert_not_awaited()
+
+
+async def test_non_string_recovery_key_does_not_crash():
+    """Malformed recovery-key payloads must be rejected, not raise a 500.
+
+    Constant-time comparison via hmac.compare_digest on bytes requires the
+    input to be a str; other JSON types must fail closed.
+    """
+    client, reset_password, _ = await _create_client()
+
+    resp = await client.post(
+        '/api/v1/user/reset-password',
+        json={'user': 'admin@example.com', 'recovery_key': 12345, 'new_password': 'NewPass1!'},
+    )
+
+    assert resp.status_code == 403
+    reset_password.assert_not_awaited()
+
+
+async def test_non_ascii_recovery_key_does_not_crash():
+    """Non-ASCII keys must compare safely (encode-based constant-time compare)."""
+    client, _, _ = await _create_client()
+
+    resp = await client.post(
+        '/api/v1/user/reset-password',
+        json={'user': 'admin@example.com', 'recovery_key': '奇数密钥不是ASCII', 'new_password': 'NewPass1!'},
+    )
+
+    assert resp.status_code == 403
+
+
+async def test_lockout_after_repeated_failures():
+    """After MAX failures even a correct key must be rejected with 429 (#2392).
+
+    The legacy endpoint accepted every guess independently; with a 24-bit key
+    the whole keyspace could be exhausted via concurrent requests.
+    """
+    client, reset_password, _ = await _create_client()
+
+    for _ in range(user_module._MAX_RECOVERY_KEY_FAILURES):
+        resp = await client.post('/api/v1/user/reset-password', json=_payload(key='WRONG'))
+        assert resp.status_code == 403
+
+    # The very next request carries the CORRECT key but is locked out.
+    resp = await client.post('/api/v1/user/reset-password', json=_payload())
+    assert resp.status_code == 429
+    reset_password.assert_not_awaited()
+
+
+async def test_lockout_rejects_before_touching_user_lookup():
+    """Lockout must reject early, before the sleep and any service calls."""
+    client, _, get_user_by_email = await _create_client()
+
+    user_module._recovery_key_state['failures'] = user_module._MAX_RECOVERY_KEY_FAILURES
+    user_module._recovery_key_state['locked_until'] = float('inf')
+
+    resp = await client.post('/api/v1/user/reset-password', json=_payload())
+
+    assert resp.status_code == 429
+    get_user_by_email.assert_not_awaited()
+
+
+async def test_lockout_expires_and_allows_again():
+    """Once the lockout window passes, a correct key works again."""
+    client, reset_password, _ = await _create_client()
+
+    user_module._recovery_key_state['failures'] = user_module._MAX_RECOVERY_KEY_FAILURES
+    user_module._recovery_key_state['locked_until'] = 0.0  # expired
+
+    resp = await client.post('/api/v1/user/reset-password', json=_payload())
+
+    assert resp.status_code == 200
+    reset_password.assert_awaited_once()
+
+
+async def test_success_resets_failure_counter():
+    """A successful reset clears the failure counter, so honest admins are not locked out."""
+    client, _, _ = await _create_client()
+
+    for _ in range(user_module._MAX_RECOVERY_KEY_FAILURES - 1):
+        await client.post('/api/v1/user/reset-password', json=_payload(key='WRONG'))
+
+    resp = await client.post('/api/v1/user/reset-password', json=_payload())
+    assert resp.status_code == 200
+
+    # One more typo after a success must not immediately lock out.
+    resp = await client.post('/api/v1/user/reset-password', json=_payload(key='WRONG'))
+    assert resp.status_code == 403
+
+    resp = await client.post('/api/v1/user/reset-password', json=_payload())
+    assert resp.status_code == 200

--- a/tests/unit_tests/api/test_user_reset_password.py
+++ b/tests/unit_tests/api/test_user_reset_password.py
@@ -4,14 +4,17 @@ Covers two attack surfaces reported in GHSA-4xcp-6758-rxqv:
 
 1. ``genkeys.py`` generated ``system.recovery_key`` with only 24 bits of
    entropy (``secrets.token_hex(3)``), making the whole keyspace brute-forceable.
-2. ``POST /api/v1/user/reset-password`` (unauthenticated) had no lockout, so
-   concurrent guesses bypassed its fixed ``asyncio.sleep(3)`` delay, and the
-   key comparison used ``!=`` instead of a constant-time comparison.
+2. ``POST /api/v1/user/reset-password`` (unauthenticated) checked its failure
+   counter across ``await`` points, so concurrent guesses all passed the gate
+   before any accounting happened; admission is now a synchronous fixed-window
+   quota consumed at entry, plus constant-time key comparison.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -28,13 +31,13 @@ STORED_KEY = 'Rk9SX1RFU1RfUkVDT1ZFUllfS0VZXzEyMzQ1Njc4OTA='
 
 
 @pytest.fixture(autouse=True)
-def _reset_lockout_state():
-    """Reset the module-level failure counter before each test."""
-    user_module._recovery_key_state['failures'] = 0
-    user_module._recovery_key_state['locked_until'] = 0.0
+def _reset_quota_state():
+    """Reset the module-level admission-quota state before each test."""
+    user_module._reset_password_state['window_started_at'] = 0.0
+    user_module._reset_password_state['attempts'] = 0
     yield
-    user_module._recovery_key_state['failures'] = 0
-    user_module._recovery_key_state['locked_until'] = 0.0
+    user_module._reset_password_state['window_started_at'] = 0.0
+    user_module._reset_password_state['attempts'] = 0
 
 
 @pytest.fixture(autouse=True)
@@ -100,7 +103,7 @@ async def test_recovery_key_generation_preserves_existing_key():
 
 
 # ---------------------------------------------------------------------------
-# POST /api/v1/user/reset-password: lockout + constant-time compare
+# POST /api/v1/user/reset-password: admission quota + constant-time compare
 # ---------------------------------------------------------------------------
 
 
@@ -184,30 +187,30 @@ async def test_non_ascii_recovery_key_does_not_crash():
     assert resp.status_code == 403
 
 
-async def test_lockout_after_repeated_failures():
-    """After MAX failures even a correct key must be rejected with 429 (#2392).
+async def test_quota_exhausted_after_max_attempts():
+    """After MAX admitted attempts even a correct key must be rejected with 429 (#2392).
 
-    The legacy endpoint accepted every guess independently; with a 24-bit key
-    the whole keyspace could be exhausted via concurrent requests.
+    Every admission consumes quota regardless of outcome; the legacy endpoint
+    accepted every guess independently, exhausting the 24-bit keyspace via bursts.
     """
     client, reset_password, _ = await _create_client()
 
-    for _ in range(user_module._MAX_RECOVERY_KEY_FAILURES):
+    for _ in range(user_module._MAX_RESET_ATTEMPTS_PER_WINDOW):
         resp = await client.post('/api/v1/user/reset-password', json=_payload(key='WRONG'))
         assert resp.status_code == 403
 
-    # The very next request carries the CORRECT key but is locked out.
+    # The very next request carries the CORRECT key but has no quota left.
     resp = await client.post('/api/v1/user/reset-password', json=_payload())
     assert resp.status_code == 429
     reset_password.assert_not_awaited()
 
 
-async def test_lockout_rejects_before_touching_user_lookup():
-    """Lockout must reject early, before the sleep and any service calls."""
+async def test_quota_rejects_before_touching_user_lookup():
+    """An exhausted quota must reject early, before the sleep and any service calls."""
     client, _, get_user_by_email = await _create_client()
 
-    user_module._recovery_key_state['failures'] = user_module._MAX_RECOVERY_KEY_FAILURES
-    user_module._recovery_key_state['locked_until'] = float('inf')
+    user_module._reset_password_state['attempts'] = user_module._MAX_RESET_ATTEMPTS_PER_WINDOW
+    user_module._reset_password_state['window_started_at'] = time.monotonic()
 
     resp = await client.post('/api/v1/user/reset-password', json=_payload())
 
@@ -215,12 +218,12 @@ async def test_lockout_rejects_before_touching_user_lookup():
     get_user_by_email.assert_not_awaited()
 
 
-async def test_lockout_expires_and_allows_again():
-    """Once the lockout window passes, a correct key works again."""
+async def test_window_rolls_over_and_admits_again():
+    """Once the fixed window elapses, the quota resets and a correct key works again."""
     client, reset_password, _ = await _create_client()
 
-    user_module._recovery_key_state['failures'] = user_module._MAX_RECOVERY_KEY_FAILURES
-    user_module._recovery_key_state['locked_until'] = 0.0  # expired
+    user_module._reset_password_state['attempts'] = user_module._MAX_RESET_ATTEMPTS_PER_WINDOW
+    user_module._reset_password_state['window_started_at'] = time.monotonic() - user_module._RESET_WINDOW_SECONDS - 1
 
     resp = await client.post('/api/v1/user/reset-password', json=_payload())
 
@@ -228,19 +231,51 @@ async def test_lockout_expires_and_allows_again():
     reset_password.assert_awaited_once()
 
 
-async def test_success_resets_failure_counter():
-    """A successful reset clears the failure counter, so honest admins are not locked out."""
+async def test_success_does_not_restore_quota():
+    """A successful reset does NOT restore quota: brute-force budget survives wins (#2392).
+
+    The legacy clear-on-success let attackers interleave correct-looking states;
+    success only proves knowledge of the key once, it must not refill attempts.
+    """
     client, _, _ = await _create_client()
 
-    for _ in range(user_module._MAX_RECOVERY_KEY_FAILURES - 1):
-        await client.post('/api/v1/user/reset-password', json=_payload(key='WRONG'))
+    for _ in range(user_module._MAX_RESET_ATTEMPTS_PER_WINDOW - 1):
+        resp = await client.post('/api/v1/user/reset-password', json=_payload(key='WRONG'))
+        assert resp.status_code == 403
 
+    # Last slot is spent on the genuine reset.
     resp = await client.post('/api/v1/user/reset-password', json=_payload())
     assert resp.status_code == 200
 
-    # One more typo after a success must not immediately lock out.
-    resp = await client.post('/api/v1/user/reset-password', json=_payload(key='WRONG'))
-    assert resp.status_code == 403
-
+    # Quota is exhausted; even a correct key waits for the next window.
     resp = await client.post('/api/v1/user/reset-password', json=_payload())
-    assert resp.status_code == 200
+    assert resp.status_code == 429
+
+
+async def test_concurrent_burst_cannot_bypass_quota(monkeypatch):
+    """A 20-request burst yields exactly {403: 5, 429: 15} (#2392 regression).
+
+    The vulnerable version accounted failures after several awaits, letting all
+    concurrent requests pass the gate ({403: 20}). Admission is now synchronous
+    and await-free, so total admissions are capped regardless of scheduling.
+    """
+
+    # Swap the AsyncMock sleep for a real cooperative yield so tasks actually
+    # interleave mid-handler like they do under production load.
+    async def _yield_sleep(_seconds):
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(user_module, 'asyncio', SimpleNamespace(sleep=_yield_sleep))
+
+    client, reset_password, _ = await _create_client()
+
+    responses = await asyncio.gather(
+        *(client.post('/api/v1/user/reset-password', json=_payload(key='WRONG')) for _ in range(20))
+    )
+
+    status_counts: dict[int, int] = {}
+    for resp in responses:
+        status_counts[resp.status_code] = status_counts.get(resp.status_code, 0) + 1
+
+    assert status_counts == {403: 5, 429: 15}
+    reset_password.assert_not_awaited()

--- a/tests/unit_tests/api/test_user_reset_password.py
+++ b/tests/unit_tests/api/test_user_reset_password.py
@@ -27,7 +27,7 @@ from langbot.pkg.core.stages.genkeys import GenKeysStage
 
 pytestmark = pytest.mark.asyncio
 
-STORED_KEY = 'Rk9SX1RFU1RfUkVDT1ZFUllfS0VZXzEyMzQ1Njc4OTA='
+STORED_KEY = 'ABCD2345'
 
 
 @pytest.fixture(autouse=True)
@@ -47,7 +47,7 @@ def _fast_sleep(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# genkeys.py: recovery-key entropy
+# genkeys.py: recovery-key generation and compatibility
 # ---------------------------------------------------------------------------
 
 
@@ -65,18 +65,15 @@ def _make_genkeys_ap(existing_key: str) -> SimpleNamespace:
     )
 
 
-async def test_recovery_key_generation_uses_high_entropy():
-    """Newly generated recovery keys must carry at least 256 bits (#2392).
-
-    The legacy generator produced 6 hex chars (24 bits); the keyspace was
-    exhaustible within hours. The replacement must be at least 32 chars.
-    """
+async def test_recovery_key_generation_is_short_and_unambiguous():
+    """Eight random base32 characters balance manual entry and online throttling."""
     ap = _make_genkeys_ap(existing_key='')
 
     await GenKeysStage().run(ap)
 
     key = ap.instance_config.data['system']['recovery_key']
-    assert len(key) >= 32, f'recovery key has only {len(key)} chars'
+    assert len(key) == 8
+    assert set(key) <= set('23456789ABCDEFGHJKLMNPQRSTUVWXYZ')
     assert ap.instance_config.dump_config.called
 
 
@@ -92,14 +89,36 @@ async def test_legacy_low_entropy_key_preserved_with_warning(caplog):
     assert not ap.instance_config.dump_config.called
 
 
-async def test_recovery_key_generation_preserves_existing_key():
+@pytest.mark.parametrize('existing_key', ['ABC123', 'ABCD2345', 'aB-_' * 10 + 'xYz', '自定义恢复密钥'])
+async def test_recovery_key_generation_preserves_existing_key(existing_key):
     """An explicitly configured recovery key must not be regenerated on boot."""
-    ap = _make_genkeys_ap(existing_key='my-own-strong-recovery-key-0123456789')
+    ap = _make_genkeys_ap(existing_key=existing_key)
 
     await GenKeysStage().run(ap)
 
-    assert ap.instance_config.data['system']['recovery_key'] == 'my-own-strong-recovery-key-0123456789'
+    assert ap.instance_config.data['system']['recovery_key'] == existing_key
     assert not ap.instance_config.dump_config.called
+
+
+async def test_generated_key_is_preserved_without_legacy_warning(caplog):
+    """A restart must not warn about or replace the new eight-character key."""
+    ap = _make_genkeys_ap(existing_key='')
+    await GenKeysStage().run(ap)
+    key = ap.instance_config.data['system']['recovery_key']
+    assert len(key) == 8
+    ap.instance_config.dump_config.reset_mock()
+    with caplog.at_level(logging.WARNING, logger='langbot.pkg.core.stages.genkeys'):
+        await GenKeysStage().run(ap)
+    assert ap.instance_config.data['system']['recovery_key'] == key
+    assert not caplog.records
+    ap.instance_config.dump_config.assert_not_awaited()
+
+
+async def test_eight_character_key_does_not_trigger_legacy_warning(caplog):
+    ap = _make_genkeys_ap(existing_key='ABCD2345')
+    with caplog.at_level(logging.WARNING, logger='langbot.pkg.core.stages.genkeys'):
+        await GenKeysStage().run(ap)
+    assert not caplog.records
 
 
 # ---------------------------------------------------------------------------
@@ -107,7 +126,7 @@ async def test_recovery_key_generation_preserves_existing_key():
 # ---------------------------------------------------------------------------
 
 
-async def _create_client():
+async def _create_client(stored_key: str = STORED_KEY):
     """Create a Quart test client with a mocked Application."""
     quart_app = quart.Quart(__name__)
 
@@ -122,7 +141,7 @@ async def _create_client():
             reset_password=reset_password,
         ),
         instance_config=SimpleNamespace(
-            data={'system': {'recovery_key': STORED_KEY}},
+            data={'system': {'recovery_key': stored_key}},
         ),
     )
 
@@ -137,11 +156,12 @@ def _payload(key: str = STORED_KEY) -> dict:
     return {'user': 'admin@example.com', 'recovery_key': key, 'new_password': 'NewPass1!'}
 
 
-async def test_correct_key_resets_password():
-    """A correct recovery key resets the password and returns success."""
-    client, reset_password, _ = await _create_client()
+@pytest.mark.parametrize('key', [STORED_KEY, 'ABC123', 'aB-_' * 10 + 'xYz', '自定义恢复密钥'])
+async def test_correct_key_resets_password(key):
+    """New, legacy and explicitly configured keys all remain usable verbatim."""
+    client, reset_password, _ = await _create_client(stored_key=key)
 
-    resp = await client.post('/api/v1/user/reset-password', json=_payload())
+    resp = await client.post('/api/v1/user/reset-password', json=_payload(key))
 
     assert resp.status_code == 200
     assert (await resp.get_json())['code'] == 0
@@ -175,13 +195,14 @@ async def test_non_string_recovery_key_does_not_crash():
     reset_password.assert_not_awaited()
 
 
-async def test_non_ascii_recovery_key_does_not_crash():
+@pytest.mark.parametrize('key', ['奇数密钥不是ASCII', '\ud800', '\udfff'])
+async def test_non_ascii_recovery_key_does_not_crash(key):
     """Non-ASCII keys must compare safely (encode-based constant-time compare)."""
     client, _, _ = await _create_client()
 
     resp = await client.post(
         '/api/v1/user/reset-password',
-        json={'user': 'admin@example.com', 'recovery_key': '奇数密钥不是ASCII', 'new_password': 'NewPass1!'},
+        json={'user': 'admin@example.com', 'recovery_key': key, 'new_password': 'NewPass1!'},
     )
 
     assert resp.status_code == 403

--- a/web/src/app/reset-password/page.tsx
+++ b/web/src/app/reset-password/page.tsx
@@ -7,12 +7,6 @@ import {
   CardTitle,
   CardDescription,
 } from '@/components/ui/card';
-import {
-  InputOTP,
-  InputOTPGroup,
-  InputOTPSlot,
-  InputOTPSeparator,
-} from '@/components/ui/input-otp';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
@@ -28,13 +22,11 @@ import {
 import { useState } from 'react';
 import { httpClient } from '@/app/infra/http/HttpClient';
 import { useNavigate } from 'react-router-dom';
-import { Mail, Lock, ArrowLeft } from 'lucide-react';
+import { Mail, Lock, ArrowLeft, KeyRound } from 'lucide-react';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
-
-const REGEXP_ONLY_DIGITS_AND_CHARS = /^[0-9a-zA-Z]+$/;
 
 const formSchema = (t: (key: string) => string) =>
   z.object({
@@ -136,28 +128,17 @@ export default function ResetPassword() {
                       {t('resetPassword.recoveryKeyDescription')}
                     </FormDescription>
                     <FormControl>
-                      <InputOTP
-                        maxLength={6}
-                        value={field.value}
-                        pattern={REGEXP_ONLY_DIGITS_AND_CHARS.source}
-                        onChange={(value) => {
-                          // 将输入的值转换为大写
-                          const upperValue = value.toUpperCase();
-                          field.onChange(upperValue);
-                        }}
-                      >
-                        <InputOTPGroup>
-                          <InputOTPSlot index={0} />
-                          <InputOTPSlot index={1} />
-                          <InputOTPSlot index={2} />
-                        </InputOTPGroup>
-                        <InputOTPSeparator />
-                        <InputOTPGroup>
-                          <InputOTPSlot index={3} />
-                          <InputOTPSlot index={4} />
-                          <InputOTPSlot index={5} />
-                        </InputOTPGroup>
-                      </InputOTP>
+                      {/* Recovery keys are case-sensitive base64url strings; send them verbatim */}
+                      <div className="relative">
+                        <KeyRound className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                        <Input
+                          placeholder={t('resetPassword.enterRecoveryKey')}
+                          className="pl-10 font-mono"
+                          autoComplete="off"
+                          spellCheck={false}
+                          {...field}
+                        />
+                      </div>
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/web/tests/e2e/reset-password.spec.ts
+++ b/web/tests/e2e/reset-password.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { installLangBotApiMocks } from './fixtures/langbot-api';
+
+const resetEndpoint = '**/api/v1/user/reset-password';
+const email = 'reset-password@example.com';
+const newPassword = 'Regression-password-2026!';
+const successMessage = 'Password reset successfully, please login';
+const failureMessage =
+  'Password reset failed, please check your email and recovery key';
+
+async function fillResetForm(page: Page, recoveryKey: string) {
+  await page.goto('/reset-password');
+  await page.getByPlaceholder('Enter email address').fill(email);
+  const recoveryInput = page.getByPlaceholder('Enter recovery key');
+  await recoveryInput.fill(recoveryKey);
+  await expect(recoveryInput).toHaveValue(recoveryKey);
+  await page.getByPlaceholder('Enter new password').fill(newPassword);
+}
+
+test.beforeEach(async ({ page }) => {
+  await installLangBotApiMocks(page, { authenticated: false });
+});
+
+const recoveryKeys = [
+  { name: 'eight-character recovery code', value: '2A3B4C5D' },
+  { name: 'six-character legacy recovery key', value: 'ABC123' },
+  {
+    name: '43-character mixed-case base64url recovery key',
+    value: 'aB-_'.repeat(10) + 'xYz',
+  },
+];
+
+for (const { name, value } of recoveryKeys) {
+  test(`submits the ${name} verbatim and returns to login`, async ({
+    page,
+  }) => {
+    const requests: { method: string; body: unknown }[] = [];
+    await page.route(resetEndpoint, async (route) => {
+      requests.push({
+        method: route.request().method(),
+        body: route.request().postDataJSON(),
+      });
+      await route.fulfill({
+        status: 200,
+        json: { code: 0, msg: 'ok', data: { user: email } },
+      });
+    });
+
+    await fillResetForm(page, value);
+    await page
+      .getByRole('button', { name: 'Reset Password', exact: true })
+      .click();
+
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByText(successMessage, { exact: true })).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Login with password', exact: true }),
+    ).toBeVisible();
+    expect(requests).toEqual([
+      {
+        method: 'POST',
+        body: { user: email, recovery_key: value, new_password: newPassword },
+      },
+    ]);
+    await expect(page.getByText(failureMessage, { exact: true })).toHaveCount(
+      0,
+    );
+  });
+}
+
+test('HTTP 429 shows failure, stays on reset-password, and reenables submission', async ({
+  page,
+}) => {
+  const recoveryKey = '2A3B4C5D';
+  const requests: { method: string; body: unknown }[] = [];
+  let releaseResponse!: () => void;
+  const responseGate = new Promise<void>((resolve) => {
+    releaseResponse = resolve;
+  });
+  await page.route(resetEndpoint, async (route) => {
+    requests.push({
+      method: route.request().method(),
+      body: route.request().postDataJSON(),
+    });
+    await responseGate;
+    await route.fulfill({
+      status: 429,
+      json: { code: -1, msg: 'Too many attempts, try again later' },
+    });
+  });
+
+  await fillResetForm(page, recoveryKey);
+  const submit = page.locator('button[type="submit"]');
+  await submit.click();
+  try {
+    await expect.poll(() => requests.length).toBe(1);
+    await expect(submit).toBeDisabled();
+    await expect(submit).toHaveText('Resetting...');
+  } finally {
+    releaseResponse();
+  }
+
+  await expect(page.getByText(failureMessage, { exact: true })).toBeVisible();
+  await expect(submit).toBeEnabled();
+  await expect(submit).toHaveText('Reset Password');
+  await expect(page).toHaveURL(/\/reset-password$/);
+  await expect(page.getByText(successMessage, { exact: true })).toHaveCount(0);
+  await expect(page.getByPlaceholder('Enter recovery key')).toHaveValue(
+    recoveryKey,
+  );
+  expect(requests).toEqual([
+    {
+      method: 'POST',
+      body: {
+        user: email,
+        recovery_key: recoveryKey,
+        new_password: newPassword,
+      },
+    },
+  ]);
+});


### PR DESCRIPTION
Fixes #2392 (GHSA-4xcp-6758-rxqv).

## Summary

Harden the unauthenticated password-recovery endpoint without making recovery impractical to type.

- **Eight-character recovery codes:** new codes use eight independent `secrets.choice` draws from `23456789ABCDEFGHJKLMNPQRSTUVWXYZ` (32 symbols / 40 random bits). There is no lowercase and no `0/O` or `1/I` ambiguity. This is an online recovery code protected by throttling, not a general-purpose API token.
- **Concurrency-safe admission quota:** at most five admitted requests per fixed 15-minute window in one process/event loop. The check and reservation happen together before any handler await or body parsing. All admitted requests consume quota; success does not refill it. Excess requests return HTTP 429 before the slow path.
- **Constant-time comparison:** retain byte-based `hmac.compare_digest`; non-string and invalid UTF-8 surrogate input is rejected without changing a password.
- **Existing keys remain unchanged:** six-character legacy keys, already-generated 43-character keys, and custom configured keys remain usable verbatim. Short legacy keys produce a warning; new eight-character codes do not produce that warning on the next startup.
- **Compatible reset form:** plain input instead of six-slot OTP, with no truncation or forced uppercasing.

## Security boundary and product decision

The original issue was valid: asynchronous sleep is not a global throttle. The final fix combines a larger random code space with actual admission control rather than choosing API-key-sized recovery strings by default. The eight-character length is an explicit maintainer product decision.

The quota is process-local and resets with the process. Multi-process/multi-replica deployments need a shared upstream limiter. An unauthenticated caller can exhaust the recovery window and delay legitimate recovery. A fixed window is not a sliding-window guarantee, and no brute-force lifetime estimate applies if the limiter is bypassed or repeatedly reset.

## Verification

- Recovery unit coverage: exact eight-character alphabet/length, existing-key preservation, no spurious startup warning, correct/wrong/malformed keys, Unicode surrogates, fixed-window expiry, success consuming quota, and concurrent burst rejection.
- Real SQLite integration: generate an eight-character code, initialize an account, reject a wrong code, reset using the generated code, verify old password rejection and new password login through the actual HTTP handlers and UserService.
- Committed Chromium regression tests: eight-character, legacy six-character, and mixed-case 43-character keys are submitted verbatim; HTTP 429 displays failure and reenables the form. Browser API responses are intercepted; no real account is modified by those browser tests.
- Local focused backend run: **39 passed** (22 recovery unit tests, one SQLite journey, 16 API smoke tests).
- Focused browser run: **4 passed**. Production frontend build, changed-page/test ESLint, and the repository's CI Ruff commands passed locally.
- The full local unit run timed out; it is not claimed as a local pass. **Final CI is green on `c32b2bc29d85d03de9d0c4182daf26cedc3e230b`**: Python 3.11/3.12/3.13 unit suites, Fast Integration, E2E Startup, Box Integration, Coverage Gate, Playwright Smoke, Ruff, Frontend Lint, and CLA. [Unit/integration run](https://github.com/langbot-app/LangBot/actions/runs/34138177599) · [Browser run](https://github.com/langbot-app/LangBot/actions/runs/34138177553).

No dependency or database migration is introduced.
