### PR TITLE
fix(monitoring): restore SQLite token statistics

### DIFF
--- a/src/langbot/pkg/persistence/tenant_uow.py
+++ b/src/langbot/pkg/persistence/tenant_uow.py
@@ -209,7 +209,7 @@ _ALLOWED_SCOPED_BUILTIN_FUNCTION_TYPES = {
     'now': sqlalchemy.sql.functions.now,
     'sum': sqlalchemy.sql.functions.sum,
 }
-_ALLOWED_SCOPED_GENERIC_FUNCTIONS = frozenset({'date_trunc', 'length', 'nullif'})
+_ALLOWED_SCOPED_GENERIC_FUNCTIONS = frozenset({'date_trunc', 'length', 'nullif', 'strftime'})
 _ALLOWED_SCOPED_CUSTOM_OPERATORS = frozenset({'<=>'})
 _ALLOWED_SCOPED_STATEMENT_TYPES = (
     sqlalchemy.sql.dml.UpdateBase,

--- a/tests/integration/persistence/test_migrations_postgres.py
+++ b/tests/integration/persistence/test_migrations_postgres.py
@@ -115,6 +115,7 @@ class _CapacityPluginRuntimeHandler:
     def __init__(self) -> None:
         self.bindings: dict[str, typing.Any] = {}
         self.reconciled: tuple[typing.Any, ...] = ()
+        self.reconcile_timeout: float | None = None
 
     def register_installation_binding(
         self,
@@ -132,8 +133,14 @@ class _CapacityPluginRuntimeHandler:
     def unregister_installation_binding(self, binding) -> None:
         self.bindings.pop(binding.installation_uuid, None)
 
-    async def reconcile_plugin_installations(self, desired_states) -> dict:
+    async def reconcile_plugin_installations(
+        self,
+        desired_states,
+        *,
+        timeout: float | None = None,
+    ) -> dict:
         self.reconciled = tuple(desired_states)
+        self.reconcile_timeout = timeout
         return {
             'applied': [],
             'removed': [],
@@ -1034,6 +1041,7 @@ class TestPostgreSQLTenantRuntime:
             assert not mcp_loader._hosted_mcp_tasks
             assert len(plugin_handler.reconciled) == workspace_count
             assert len(plugin_handler.bindings) == workspace_count
+            assert plugin_handler.reconcile_timeout == 300.0
             assert all(count == workspace_count for count in statement_counts.values()), statement_counts
             if max_elapsed is not None:
                 assert elapsed <= max_elapsed

--- a/tests/unit_tests/persistence/test_tenant_uow.py
+++ b/tests/unit_tests/persistence/test_tenant_uow.py
@@ -964,6 +964,7 @@ async def test_scoped_session_rejects_raw_or_unapproved_sql(
             sa.func.date_trunc('hour', sa.column('timestamp')),
             sa.func.length(sa.literal('value')),
             sa.func.nullif(sa.literal('value'), sa.literal('')),
+            sa.func.strftime('%Y-%m-%d %H:00', sa.column('timestamp')),
         ),
         sa.select(sa.column('embedding').op('<=>')(sa.literal([0.1]))),
         sa.select(sa.cast(sa.column('embedding'), Vector(384))),
@@ -975,6 +976,19 @@ async def test_scoped_session_rejects_raw_or_unapproved_sql(
 )
 async def test_scoped_sql_structure_allows_only_the_production_vocabulary(statement) -> None:
     _validate_scoped_statement_call((statement,), {})
+
+
+async def test_scoped_session_executes_sqlite_strftime() -> None:
+    engine = create_async_engine('sqlite+aiosqlite:///:memory:')
+    try:
+        async with TenantUnitOfWork(engine, 'workspace-a') as uow:
+            result = await uow.session.execute(
+                sa.select(sa.func.strftime('%Y-%m-%d %H:00', sa.literal('2026-08-28 03:45:00')))
+            )
+
+        assert result.scalar_one() == '2026-08-28 03:00'
+    finally:
+        await engine.dispose()
 
 
 async def test_scoped_sql_rejects_public_execution_options() -> None:

--- a/web/src/app/home/monitoring/components/TokenMonitoring.tsx
+++ b/web/src/app/home/monitoring/components/TokenMonitoring.tsx
@@ -20,6 +20,7 @@ import {
   TrendingUp,
 } from 'lucide-react';
 import { httpClient } from '@/app/infra/http/HttpClient';
+import { getErrorMessage } from '../utils';
 
 interface TokenSummary {
   total_calls: number;
@@ -152,7 +153,7 @@ export default function TokenMonitoring({
       });
       setStats(result);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(getErrorMessage(e));
     } finally {
       setLoading(false);
     }

--- a/web/src/app/home/monitoring/utils.ts
+++ b/web/src/app/home/monitoring/utils.ts
@@ -1,0 +1,12 @@
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'msg' in error &&
+    typeof error.msg === 'string'
+  ) {
+    return error.msg;
+  }
+  return String(error);
+}

--- a/web/tests/unit/token-monitoring-error.test.mjs
+++ b/web/tests/unit/token-monitoring-error.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import ts from 'typescript';
+import { fileURLToPath } from 'node:url';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const utilsPath = path.resolve(
+  currentDirectory,
+  '../../src/app/home/monitoring/utils.ts',
+);
+const componentPath = path.resolve(
+  currentDirectory,
+  '../../src/app/home/monitoring/components/TokenMonitoring.tsx',
+);
+
+function loadMonitoringUtils() {
+  const source = fs.readFileSync(utilsPath, 'utf8');
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS },
+  }).outputText;
+  const loadedModule = { exports: {} };
+  new Function('require', 'module', 'exports', compiled)(
+    () => {
+      throw new Error('Monitoring utils must not have runtime imports');
+    },
+    loadedModule,
+    loadedModule.exports,
+  );
+  return loadedModule.exports;
+}
+
+const { getErrorMessage } = loadMonitoringUtils();
+
+test('token monitoring extracts messages from structured API errors', () => {
+  assert.equal(
+    getErrorMessage({
+      code: 500,
+      msg: 'SQLite aggregation failed',
+      data: null,
+    }),
+    'SQLite aggregation failed',
+  );
+  assert.equal(getErrorMessage(new Error('Network failed')), 'Network failed');
+  assert.equal(getErrorMessage('Request failed'), 'Request failed');
+});
+
+test('token monitoring uses the structured API error helper', () => {
+  const source = fs.readFileSync(componentPath, 'utf8');
+  assert.match(source, /import \{ getErrorMessage \} from '\.\.\/utils';/);
+  assert.match(source, /setError\(getErrorMessage\(e\)\)/);
+});


### PR DESCRIPTION
## 概述 / Overview

Fixes #2468.

- allows the existing SQLite token-statistics bucket query to use `strftime` through `TenantUnitOfWork`;
- preserves the backend `msg` when the token dashboard receives the HTTP client's structured `{ code, msg, data }` error object, instead of displaying `[object Object]`;
- adds a real SQLite scoped-session execution regression and behavioral tests for frontend error extraction/wiring;
- repairs the existing PostgreSQL capacity-test stub to accept and assert the runtime reconcile timeout now passed by `master` (the first CI run exposed this unrelated deterministic base regression).

This is an independent reimplementation of the focused fix discussed in #2473 because that contribution cannot be merged without its author's CLA signature.

### 更改前后对比截图 / Screenshots

No layout change.

Before: token monitoring returned HTTP 500 on SQLite, and the UI rendered `[object Object]`.

After: SQLite time buckets execute through the tenant SQL guard; future structured API failures display their backend message.

## Validation

- `uv run pytest tests/unit_tests/persistence/test_tenant_uow.py -q --tb=short` — 118 passed
- `uv run pytest tests/unit_tests/api/service/test_monitoring_tenancy.py::test_token_statistics_aggregate_and_limit_groups_in_database -q --tb=short` — passed
- `uv run ruff check ...` — passed
- `uv run ruff format --check ...` — passed
- `pnpm test:unit` — 54 passed
- `pnpm lint` — 0 errors (34 existing warnings)
- `pnpm build` — passed
- `pnpm exec prettier --check ...` — passed
- `git diff --check` — passed
- independent pre-commit review — passed with no security or logic findings

## 检查清单 / Checklist

- [x] 阅读仓库贡献指引 / Read the contribution guide
- [x] 已签署 CLA / Signed the CLA
- [x] 已与项目维护者沟通（#2468）/ Communicated with the maintainer
- [x] 已自行测试更改 / Tested the changes

### 项目维护者完成 / For project maintainer

- [x] 相关 issue 已链接 / Related issue linked
- [x] 无配置或迁移变更 / No configuration or migration changes
- [x] 无新增依赖 / No new dependencies
- [x] 无需文档更新 / No documentation update required
