### PR TITLE
fix(plugin): return not found after removal

### DIFF
--- a/src/langbot/pkg/plugin/connector.py
+++ b/src/langbot/pkg/plugin/connector.py
@@ -1913,9 +1913,14 @@ class PluginRuntimeConnector(ManagedRuntimeConnector):
 
         return plugins
 
-    async def get_plugin_info(self, author: str, plugin_name: str) -> dict[str, Any]:
+    async def get_plugin_info(self, author: str, plugin_name: str) -> dict[str, Any] | None:
         runtime_handler = self._runtime_handler()
-        binding = await self._target_binding(author, plugin_name)
+        try:
+            binding = await self._target_binding(author, plugin_name)
+        except ValueError as exc:
+            if str(exc) == f'Plugin {author}/{plugin_name} is not installed in this Workspace':
+                return None
+            raise
         with runtime_handler.installation_scope(binding):
             return await runtime_handler.get_plugin_info(author, plugin_name)
 

--- a/tests/unit_tests/plugin/test_connector_methods.py
+++ b/tests/unit_tests/plugin/test_connector_methods.py
@@ -640,6 +640,19 @@ class TestGetPluginInfo:
         connector.handler.get_plugin_info.assert_called_once_with('author', 'plugin')
         assert result == {'manifest': {'metadata': {'name': 'plugin'}}}
 
+    @pytest.mark.asyncio
+    async def test_returns_none_when_plugin_is_not_installed(self):
+        connector = create_mock_connector()
+        configure_handler(connector, AsyncMock())
+        connector._target_binding = AsyncMock(
+            side_effect=ValueError('Plugin author/plugin is not installed in this Workspace')
+        )
+
+        result = await connector.get_plugin_info('author', 'plugin')
+
+        assert result is None
+        connector.handler.get_plugin_info.assert_not_awaited()
+
 
 class TestSetPluginConfig:
     """Tests for set_plugin_config method."""


### PR DESCRIPTION
## Overview

Return `None` from `PluginRuntimeConnector.get_plugin_info` when the requested plugin is no longer installed in the selected Workspace. The API route can then return its intended HTTP 404 response instead of surfacing the connector's binding lookup `ValueError` as HTTP 500.

This was found while validating the complete install/use/remove flow for #2465.

Runtime dependency installation is implemented in langbot-app/langbot-plugin-sdk#123.

### Screenshots

No UI change.

Before:

- removing a plugin succeeded, but the subsequent plugin-detail request returned HTTP 500

After:

- removing a plugin succeeds and the subsequent plugin-detail request returns HTTP 404 on both Windows and Linux

## Validation

- `pytest -q tests/unit_tests/plugin/test_connector_methods.py -k GetPluginInfo`: 2 passed
- `ruff check src/langbot/pkg/plugin/connector.py tests/unit_tests/plugin/test_connector_methods.py`
- Windows native full flow: fresh startup, initialize/login, local `.lbpkg` install, page asset request, Page API invocation with `feedparser`, removal, and HTTP 404 verification
- Linux Docker/WSL2 full flow: the same end-to-end sequence against separate LangBot and Plugin Runtime services

## Checklist

### For PR author

- [x] I have read the contribution guide.
- [x] I have signed, or will sign when prompted by the bot, the CLA.
- [ ] I have communicated with the project maintainer.
- [x] I have tested the changes and ensured they work as expected.

### For project maintainer

- [ ] Related issues are linked.
- [ ] Configuration and migrations are complete and effective.
- [ ] Dependencies are added to `pyproject.toml` and `core/bootutils/deps.py` where applicable.
- [ ] Documentation is complete.
