### PR TITLE
fix(ollama): use litellm's ollama_chat provider for native tool-calling

### DIFF
--- a/src/langbot/pkg/provider/modelmgr/requesters/litellmchat.py
+++ b/src/langbot/pkg/provider/modelmgr/requesters/litellmchat.py
@@ -573,7 +573,7 @@ class LiteLLMRequester(requester.ProviderAPIRequester):
             levels = ['provider_default', 'disabled', 'enabled']
         elif family == 'doubao':
             levels = ['provider_default', 'disabled', 'low', 'medium', 'high']
-        elif family == 'ollama':
+        elif family in ('ollama', 'ollama_chat'):
             levels = ['provider_default']
             levels.append('disabled')
             if normalized_name.startswith('gpt-oss') or '/gpt-oss' in normalized_name:
@@ -1345,7 +1345,14 @@ class LiteLLMRequester(requester.ProviderAPIRequester):
         extra_args: dict[str, typing.Any] = {},
     ) -> tuple[list[list[float]], dict]:
         """Invoke embedding and return vectors with usage info."""
-        model_name = self._build_litellm_model_name(model.model_entity.name)
+        # litellm's embedding routing has no "ollama_chat" branch (that provider
+        # exists only for /api/chat completions) — embeddings still go through
+        # the plain "ollama" provider. Requesters configured for ollama_chat
+        # (to get native tool-calling on the chat path) must fall back to
+        # "ollama" here specifically, or embedding calls raise "Unmapped LLM
+        # provider for this endpoint".
+        embedding_provider = 'ollama' if self._get_custom_llm_provider() == 'ollama_chat' else None
+        model_name = self._build_litellm_model_name(model.model_entity.name, embedding_provider)
         api_key = model.provider.token_mgr.get_token()
 
         args = {
@@ -1541,6 +1548,12 @@ class LiteLLMRequester(requester.ProviderAPIRequester):
                 event_hooks=httpclient.httpx_response_limit_hooks(),
             ) as client:
                 response = await client.get(models_url, headers=headers)
+                if response.status_code == 404 and not base_url.rstrip('/').endswith('/v1'):
+                    # Some OpenAI-compatible servers (notably a bare Ollama host,
+                    # e.g. http://host:11434) expose the model list under /v1/models
+                    # rather than /models. Providers whose configured base_url
+                    # already ends in /v1 keep their original (working) URL.
+                    response = await client.get(f'{base_url}/v1/models', headers=headers)
                 response.raise_for_status()
                 payload = await httpclient.parse_json_response(response)
 

--- a/src/langbot/pkg/provider/modelmgr/requesters/ollamachat.yaml
+++ b/src/langbot/pkg/provider/modelmgr/requesters/ollamachat.yaml
@@ -7,7 +7,7 @@ metadata:
     zh_Hans: Ollama
   icon: ollama.svg
 spec:
-  litellm_provider: ollama
+  litellm_provider: ollama_chat
   config:
   - name: base_url
     label:


### PR DESCRIPTION
Fixes #2493.

## What's wrong

The `Ollama` LLM requester declares `litellm_provider: ollama`, which routes every request through litellm's legacy `/api/generate`-based `OllamaConfig`. That config's `get_supported_openai_params()` does not include `tools`/`tool_choice` at all, so a `local-agent` pipeline using an Ollama-hosted model can never get a structured `tool_calls` response back — the model can only try to express a tool call as free text (typically inside its own `<think>` reasoning), which LangBot then has no way to execute.

Full root-cause writeup, including how it was diagnosed and ruled out against model choice / thinking / temperature / context window / tool complexity, is in #2493.

## What this changes

- `ollamachat.yaml`: `litellm_provider: ollama` -> `ollama_chat`, litellm's provider for Ollama's modern `/api/chat` endpoint, which correctly forwards `tools`/`tool_choice` and surfaces `message.tool_calls`.
- `litellmchat.py`, three small follow-ons needed because the Ollama requester definition is shared by LLM and text-embedding models:
  - `get_reasoning_capabilities`: match `family in ('ollama', 'ollama_chat')` so the reasoning-level UI still works.
  - `scan_models`: fall back to `{base_url}/v1/models` on a 404 from `{base_url}/models` (Ollama's `base_url` is a bare host and must stay that way, unlike most other OpenAI-compatible providers whose configured `base_url` already ends in `/v1`).
  - `invoke_embedding`: litellm's embedding routing has no `ollama_chat` case, only `ollama`. Explicitly override the provider prefix back to `ollama` for embedding calls specifically, so e.g. `bge-m3` keeps working after switching chat completions to `ollama_chat`.

## Testing

- `pytest tests/unit_tests/provider -k "litellm or ollama or reasoning or localagent or embed"` — 156 passed, no regressions.
- Verified live against a local Ollama 0.33.2 instance: tool-calling now returns structured `tool_calls` reliably (previously the model could only emit free-text pseudo tool-calls), `scan_models` lists models correctly, and `bge-m3` embeddings work.