### PR TITLE
fix(qqofficial): tolerate missing optional token in adapter config

### DIFF
--- a/src/langbot/pkg/platform/sources/qqofficial.py
+++ b/src/langbot/pkg/platform/sources/qqofficial.py
@@ -205,7 +205,7 @@ class QQOfficialAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter
         bot = QQOfficialClient(
             app_id=config['appid'],
             secret=config['secret'],
-            token=config['token'],
+            token=config.get('token', ''),
             logger=logger,
             unified_mode=enable_webhook,
         )


### PR DESCRIPTION
## 概述 / Overview

  Since b55f073e the `token` field is optional in `qqofficial.yaml` — the field description explicitly says *"Optional. The QR binding cannot
  return this value; the current adapter implementation does not use it either, so it can be safely left blank."* However, the adapter
  constructor still reads it with `config['token']`.

  As a result, creating a QQ Official bot with the token field left blank — which is exactly what happens after one-click QR binding, since the
  bind flow only returns `appid`/`secret` — raises `KeyError: 'token'` inside `QQOfficialAdapter.__init__`, and the API returns HTTP 500.

  Fix: read the value with `config.get('token', '')`. The value is never used by `QQOfficialClient` beyond being stored on the instance, so an
  empty-string default is safe.

  ### 更改前后对比截图 / Screenshots

  修改前 / Before — creating a bot via API with a QR-bound config (no `token` key):

```
  POST /api/v1/platform/bots → 500
  KeyError: 'token'
  File "pkg/platform/sources/qqofficial.py", line 208, in init
  token=config['token'],
```

  修改后 / After — the same request succeeds:

```
  POST /api/v1/platform/bots → 200 {"uuid": "..."}
```

  ## 检查清单 / Checklist

  ### PR 作者完成 / For PR author

  - [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide]
  (https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
  - [x] 我已签署或将在机器人提示后签署 [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。 / I have signed, or will sign when
  prompted by the bot, the [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md).
  - [ ] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
  - [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.