### PR TITLE
fix(cloud): request automatic Space launch

### DIFF
--- a/src/langbot/pkg/api/http/service/space.py
+++ b/src/langbot/pkg/api/http/service/space.py
@@ -127,7 +127,7 @@ class SpaceService:
     def get_cloud_entry_url(self) -> str:
         """Return the Space-owned Cloud selector for a Cloud Account login."""
 
-        return f'{self._get_space_config()["url"].rstrip("/")}/cloud?environment=beta'
+        return f'{self._get_space_config()["url"].rstrip("/")}/cloud?environment=beta&auto_launch=1'
 
     async def exchange_oauth_code(
         self,

--- a/tests/integration/api/test_user_space_oauth.py
+++ b/tests/integration/api/test_user_space_oauth.py
@@ -71,7 +71,9 @@ async def space_oauth_api():
     application.space_service.get_oauth_authorize_url = Mock(
         side_effect=lambda redirect_uri, state: f'https://space.example/authorize?state={state}'
     )
-    application.space_service.get_cloud_entry_url = Mock(return_value='https://space.example/cloud?environment=beta')
+    application.space_service.get_cloud_entry_url = Mock(
+        return_value='https://space.example/cloud?environment=beta&auto_launch=1'
+    )
     application.space_service.exchange_oauth_code = AsyncMock(
         return_value={
             'access_token': 'space-access-token',
@@ -143,7 +145,9 @@ async def test_cloud_login_entry_redirects_to_space_workspace_launcher(space_oau
     )
 
     assert response.status_code == 200
-    assert (await response.get_json())['data']['authorize_url'] == ('https://space.example/cloud?environment=beta')
+    assert (await response.get_json())['data']['authorize_url'] == (
+        'https://space.example/cloud?environment=beta&auto_launch=1'
+    )
     application.space_service.get_cloud_entry_url.assert_called_once_with()
     application.user_service.issue_space_oauth_state.assert_not_awaited()
 

--- a/tests/unit_tests/api/service/test_space_service.py
+++ b/tests/unit_tests/api/service/test_space_service.py
@@ -134,6 +134,18 @@ class TestSpaceServiceGetOAuthAuthorizeUrl:
         # Verify - uses default URL
         assert 'https://space.langbot.app/auth/authorize' in result
 
+    def test_cloud_entry_url_requests_automatic_launch(self):
+        """Cloud's login entry must continue through the Space launcher."""
+        ap = SimpleNamespace(
+            instance_config=SimpleNamespace(
+                data={'space': {'url': 'https://space.example/base/'}},
+            ),
+        )
+
+        result = SpaceService(ap).get_cloud_entry_url()
+
+        assert result == 'https://space.example/base/cloud?environment=beta&auto_launch=1'
+
 
 class TestSpaceServiceGetUserByEmail:
     """Tests for _get_user_by_email internal method."""


### PR DESCRIPTION
## Root cause

Cloud-mode account login was changed to enter through the Space-owned Cloud selector so a first visit can create and project the personal Workspace. The generated URL stopped at `/cloud?environment=beta`, which never continued into the existing workspace launch flow.

## Fix

- make the fixed Space Cloud-entry URL request `auto_launch=1`
- preserve invitation login on the normal OAuth callback path
- preserve Space-owned lazy personal Workspace creation and bounded Core projection catch-up

## Verification

- regression test failed before the URL change and passes after it
- 53 Space OAuth/service tests passed
- 6 direct-launch tests passed
- 66 web unit tests passed
- web production build passed
- Ruff passed for changed Python files
- changed-file ESLint passed with one pre-existing hook warning and zero errors

## Dependency / rollout order

Merge and deploy langbot-app/langbot-space first. This change is backward-compatible before that rollout (the current Space page ignores the unknown marker), but the user-visible fix only becomes complete once both sides are deployed.
