### PR TITLE
revert(cloud): remove unsigned automatic launch

### DIFF
--- a/src/langbot/pkg/api/http/service/space.py
+++ b/src/langbot/pkg/api/http/service/space.py
@@ -127,7 +127,7 @@ class SpaceService:
     def get_cloud_entry_url(self) -> str:
         """Return the Space-owned Cloud selector for a Cloud Account login."""
 
-        return f'{self._get_space_config()["url"].rstrip("/")}/cloud?environment=beta&auto_launch=1'
+        return f'{self._get_space_config()["url"].rstrip("/")}/cloud?environment=beta'
 
     async def exchange_oauth_code(
         self,

--- a/tests/integration/api/test_user_space_oauth.py
+++ b/tests/integration/api/test_user_space_oauth.py
@@ -71,9 +71,7 @@ async def space_oauth_api():
     application.space_service.get_oauth_authorize_url = Mock(
         side_effect=lambda redirect_uri, state: f'https://space.example/authorize?state={state}'
     )
-    application.space_service.get_cloud_entry_url = Mock(
-        return_value='https://space.example/cloud?environment=beta&auto_launch=1'
-    )
+    application.space_service.get_cloud_entry_url = Mock(return_value='https://space.example/cloud?environment=beta')
     application.space_service.exchange_oauth_code = AsyncMock(
         return_value={
             'access_token': 'space-access-token',
@@ -145,9 +143,7 @@ async def test_cloud_login_entry_redirects_to_space_workspace_launcher(space_oau
     )
 
     assert response.status_code == 200
-    assert (await response.get_json())['data']['authorize_url'] == (
-        'https://space.example/cloud?environment=beta&auto_launch=1'
-    )
+    assert (await response.get_json())['data']['authorize_url'] == ('https://space.example/cloud?environment=beta')
     application.space_service.get_cloud_entry_url.assert_called_once_with()
     application.user_service.issue_space_oauth_state.assert_not_awaited()
 

--- a/tests/unit_tests/api/service/test_space_service.py
+++ b/tests/unit_tests/api/service/test_space_service.py
@@ -134,18 +134,6 @@ class TestSpaceServiceGetOAuthAuthorizeUrl:
         # Verify - uses default URL
         assert 'https://space.langbot.app/auth/authorize' in result
 
-    def test_cloud_entry_url_requests_automatic_launch(self):
-        """Cloud's login entry must continue through the Space launcher."""
-        ap = SimpleNamespace(
-            instance_config=SimpleNamespace(
-                data={'space': {'url': 'https://space.example/base/'}},
-            ),
-        )
-
-        result = SpaceService(ap).get_cloud_entry_url()
-
-        assert result == 'https://space.example/base/cloud?environment=beta&auto_launch=1'
-
 
 class TestSpaceServiceGetUserByEmail:
     """Tests for _get_user_by_email internal method."""


### PR DESCRIPTION
## Reason

Independent review found that `auto_launch=1` was an unsigned, forgeable URL instruction rather than a trusted first-party launch intent.

## Revert scope
- stop generating the unsafe query marker
- restore the previous Space Cloud selector URL
- remove the corresponding literal URL assertions

## Follow-up
The automatic handoff will return with a server-validated, short-lived, one-time launch intent.

## Verification
- Space service and OAuth tests: 52 passed
