### PR TITLE
feat(provider): add llmman as a local model requester

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ _Note: Public demo environment. Do not enter sensitive information._
 | [Moonshot](https://www.moonshot.cn/)                                                                              | LLM          | ✅     |
 | [Zhipu AI](https://open.bigmodel.cn/)                                                                             | LLM          | ✅     |
 | [Ollama](https://ollama.com/)                                                                                     | Local LLM    | ✅     |
+| [llmman](https://github.com/llmmanorg/llmman)                                                                     | Local LLM    | ✅     |
 | [LM Studio](https://lmstudio.ai/)                                                                                 | Local LLM    | ✅     |
 | [Dify](https://dify.ai)                                                                                           | LLMOps       | ✅     |
 | [MCP](https://modelcontextprotocol.io/)                                                                           | Protocol     | ✅     |

--- a/src/langbot/pkg/provider/modelmgr/requesters/llmman.svg
+++ b/src/langbot/pkg/provider/modelmgr/requesters/llmman.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="12" fill="#1f2937"/>
+  <path d="M18 24l10 8-10 8" fill="none" stroke="#f9fafb" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M32 42h14" fill="none" stroke="#f9fafb" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/src/langbot/pkg/provider/modelmgr/requesters/llmmanchat.yaml
+++ b/src/langbot/pkg/provider/modelmgr/requesters/llmmanchat.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: LLMAPIRequester
+metadata:
+  name: llmman-chat
+  label:
+    en_US: llmman
+    zh_Hans: llmman
+  icon: llmman.svg
+spec:
+  # llmman (https://github.com/llmmanorg/llmman) serves the Ollama API on port 17434,
+  # so it reuses litellm's ollama_chat provider with a different default base URL.
+  litellm_provider: ollama_chat
+  config:
+  - name: base_url
+    label:
+      en_US: Base URL
+      zh_Hans: 基础 URL
+    type: string
+    required: true
+    default: http://127.0.0.1:17434
+  - name: timeout
+    label:
+      en_US: Timeout
+      zh_Hans: 超时时间
+    type: integer
+    required: true
+    default: 120
+  alias: "llmman 本地 local 本地部署 self-hosted llama.cpp vllm mlx gguf 私有化"
+  support_type:
+  - llm
+  - text-embedding
+  provider_category: self-hosted
+execution:
+  python:
+    path: ./llmmanchat.py
+    attr: LlmmanChatCompletions


### PR DESCRIPTION
## 概述 / Overview

Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API on port 17434.

- `requesters/llmmanchat.yaml`: new `LLMAPIRequester` manifest modelled on `ollamachat.yaml`. It reuses `litellm_provider: ollama_chat` with default `base_url: http://127.0.0.1:17434`, so no Python code is added and `ModelManager` routes it through the existing `LiteLLMRequester` for both `llm` and `text-embedding`.
- `requesters/llmman.svg`: neutral placeholder icon; llmman has no official logo and the picker has no fallback icon.
- `README.md`: one "Local LLM" row after Ollama (English README only).

**Testing:** `ruff check` / `ruff format --check` clean; manifest loads with the same `support_type` and litellm provider as Ollama; `pytest tests/unit_tests/provider/test_model_manager.py test_litellmchat.py test_reasoning_control.py test_model_service.py`: 176 passed. Not run against a live llmman server.

### 更改前后对比截图 / Screenshots

> N/A (manifest + README only).

## 检查清单 / Checklist

### PR 作者完成 / For PR author

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [x] 我已签署或将在机器人提示后签署 [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。 / I have signed, or will sign when prompted by the bot, the [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md).
- [ ] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] 文档编写了吗？ / Have you written the documentation?

> AI-assisted, reviewed before submitting.
