### PR TITLE
feat(api): add system context endpoint for lbctl

### DIFF
--- a/docs/API_KEY_AUTH.md
+++ b/docs/API_KEY_AUTH.md
@@ -88,6 +88,23 @@ Each endpoint accepts **either**:
 1. **User Token** (via `Authorization: Bearer <user_jwt_token>`) - for web UI and authenticated users
 2. **API Key** (via `X-API-Key` or `Authorization: Bearer <api_key>`) - for external services
 
+### Inspecting API Key Identity
+
+`GET /api/v1/system/context` validates an API key (user JWT not accepted) and returns its bound identity without requiring resource permissions:
+
+```json
+{
+  "code": 0,
+  "msg": "ok",
+  "data": {
+    "instance_uuid": "...",
+    "workspace_uuid": "...",
+    "api_key_id": "...",
+    "permissions": ["..."]
+  }
+}
+```
+
 ## Example: Model Management
 
 ### List All LLM Models

--- a/skills/skills/langbot-mcp-ops/SKILL.md
+++ b/skills/skills/langbot-mcp-ops/SKILL.md
@@ -43,6 +43,8 @@ Two kinds of key are accepted:
 Invalid, revoked, or expired keys get `401 Unauthorized`. A valid key whose
 scopes do not authorize a tool gets `403 Forbidden`.
 
+To inspect key identity and permissions, call `GET /api/v1/system/context` with the API key.
+
 ## Client configuration
 
 ```json

--- a/src/langbot/pkg/api/http/controller/groups/system.py
+++ b/src/langbot/pkg/api/http/controller/groups/system.py
@@ -15,6 +15,17 @@ from .....workspace.invitation_delivery import InvitationDeliveryService
 @group.group_class('system', '/api/v1/system')
 class SystemRouterGroup(group.RouterGroup):
     async def initialize(self) -> None:
+        @self.route('/context', methods=['GET'], auth_type=group.AuthType.API_KEY)
+        async def _(request_context: RequestContext) -> str:
+            return self.success(
+                data={
+                    'instance_uuid': request_context.instance_uuid,
+                    'workspace_uuid': request_context.workspace_uuid,
+                    'api_key_id': request_context.principal.api_key_uuid,
+                    'permissions': sorted(request_context.workspace.permissions),
+                }
+            )
+
         @self.route('/info', methods=['GET'], auth_type=group.AuthType.NONE)
         async def _() -> str:
             # Read wizard_status and wizard_progress from metadata table

--- a/tests/integration/api/test_workspaces.py
+++ b/tests/integration/api/test_workspaces.py
@@ -440,6 +440,70 @@ async def test_api_key_secret_is_one_time_and_viewer_cannot_manage_keys(workspac
     assert (await forbidden.get_json())['code'] == 'permission_denied'
 
 
+async def test_api_key_context_returns_bound_identity_without_workspace_permission(workspace_api):
+    application, client, _, owner_token = workspace_api
+    current_response = await client.get('/api/v1/workspaces/current', headers=_auth(owner_token))
+    workspace_uuid = (await current_response.get_json())['data']['workspace']['uuid']
+
+    create_response = await client.post(
+        '/api/v1/apikeys',
+        headers=_auth(owner_token, workspace_uuid),
+        json={'name': 'Context probe', 'scopes': []},
+    )
+    assert create_response.status_code == 200
+    created = (await create_response.get_json())['data']['key']
+
+    missing_auth = await client.get('/api/v1/system/context')
+    assert missing_auth.status_code == 401
+
+    invalid_auth = await client.get(
+        '/api/v1/system/context',
+        headers={'X-API-Key': 'lbk_invalid'},
+    )
+    assert invalid_auth.status_code == 401
+
+    response = await client.get(
+        '/api/v1/system/context',
+        headers={
+            'X-API-Key': created['key'],
+            'X-Workspace-Id': 'caller-selected-workspace-must-be-ignored',
+        },
+    )
+
+    assert response.status_code == 200
+    assert (await response.get_json())['data'] == {
+        'instance_uuid': application.workspace_service.instance_uuid,
+        'workspace_uuid': workspace_uuid,
+        'api_key_id': created['uuid'],
+        'permissions': [],
+    }
+
+    bearer_response = await client.get(
+        '/api/v1/system/context',
+        headers={'Authorization': f'Bearer {created["key"]}'},
+    )
+    assert bearer_response.status_code == 200
+    assert (await bearer_response.get_json())['data']['api_key_id'] == created['uuid']
+
+    jwt_response = await client.get(
+        '/api/v1/system/context',
+        headers={'Authorization': f'Bearer {owner_token}'},
+    )
+    assert jwt_response.status_code == 401
+
+    revoke_response = await client.delete(
+        f'/api/v1/apikeys/{created["id"]}',
+        headers=_auth(owner_token, workspace_uuid),
+    )
+    assert revoke_response.status_code == 200
+
+    revoked_response = await client.get(
+        '/api/v1/system/context',
+        headers={'X-API-Key': created['key']},
+    )
+    assert revoked_response.status_code == 401
+
+
 async def test_cloud_projection_is_selected_explicitly_and_collaboration_runs_in_core(
     workspace_api,
 ):


### PR DESCRIPTION
## 概述 / Overview

为外部命令行工具（`langbot-cli` / `lbctl`，对应 issue：[#2495](https://github.com/langbot-app/LangBot/issues/2495)）提供轻量级的凭证自省与上下文探测端点，方便 CLI 执行连通性校验、`whoami` 身份展示及前置权限探测。

Provide a lightweight credential introspection and context probe endpoint for external CLI tools (`langbot-cli` / `lbctl`), enabling connectivity verification, `whoami` identity inspection, and pre-flight permission checks.

### 主要改动 / Key Changes:
1. **新增探针接口 / New Endpoint**:
   - 添加 `GET /api/v1/system/context`（`AuthType.API_KEY`）。
   - 无需任何资源权限（即使 scopes 为空的 API Key 也可调用），返回当前凭证绑定的 `instance_uuid`、`workspace_uuid`、`api_key_id` 以及已排序的 `permissions` 列表。
2. **多租户安全隔离 / Multi-tenant Isolation**:
   - 严格基于数据库中 API Key 的哈希绑定关系解析工作空间，直接忽略调用方可能传入的 `X-Workspace-Id` 请求头，防止越权伪造。
3. **专属凭证鉴权 / Dedicated Authentication**:
   - 仅支持 API Key 认证（`X-API-Key` 或 `Authorization: Bearer <api_key>`），明确拒绝普通 Web User JWT（返回 401）。
4. **测试与文档 / Tests & Docs**:
   - 在 `tests/integration/api/test_workspaces.py` 中新增覆盖零权限、失效/撤销、Header 覆盖防范等完整用例。
   - 同步更新 `docs/API_KEY_AUTH.md` 与 MCP Skill 说明。

### 更改前后对比截图 / Screenshots

> 控制台调用输出 / Console Output:

修改后 / After (`GET /api/v1/system/context`):
```bash
curl -H "X-API-Key: lbk_xxxx" http://localhost:5300/api/v1/system/context
```
```json
{
  "code": 0,
  "msg": "ok",
  "data": {
    "instance_uuid": "04c278fb-b8c1-4ba2-8ef9-xxxx",
    "workspace_uuid": "b6a8276f-0043-4f9e-a0e2-xxxx",
    "api_key_id": "4a71d8bc-5690-4e55-a912-xxxx",
    "permissions": [
      "model:read",
      "bot:read"
    ]
  }
}
```

## 检查清单 / Checklist

### PR 作者完成 / For PR author

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [x] 我已签署或将在机器人提示后签署 [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。 / I have signed, or will sign when prompted by the bot, the [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md).
- [x] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] 文档编写了吗？ / Have you written the documentation?