### PR TITLE
fix: default Langflow tweaks to empty object when unset

### DIFF
--- a/src/langbot/pkg/provider/runners/langflowapi.py
+++ b/src/langbot/pkg/provider/runners/langflowapi.py
@@ -90,7 +90,7 @@ class LangflowAPIRunner(runner.RequestRunner):
         }
 
         # 如果配置中有tweaks，则添加到负载中
-        tweaks = json.loads(self.pipeline_config['ai']['langflow-api'].get('tweaks'))
+        tweaks = json.loads(self.pipeline_config['ai']['langflow-api'].get('tweaks') or '{}')
         if tweaks:
             payload['tweaks'] = tweaks
 


### PR DESCRIPTION
## What

`json.loads(None)` raised `TypeError` whenever `tweaks` was absent from the Langflow API config. Now defaults to `{}`.