### PR TITLE
feat: allow continuing after knowledge retrieval errors

### DIFF
--- a/src/langbot/pkg/provider/runners/localagent.py
+++ b/src/langbot/pkg/provider/runners/localagent.py
@@ -42,6 +42,12 @@ SANDBOX_EXEC_SYSTEM_GUIDANCE = (
 # a sandbox exec), yielding a non-terminating request and runaway cost. Set
 # generously so it never interrupts legitimate multi-step agentic workflows.
 MAX_TOOL_CALL_ROUNDS = 128
+KNOWLEDGE_RETRIEVAL_ERROR_POLICY_FAIL = 'fail'
+KNOWLEDGE_RETRIEVAL_ERROR_POLICY_CONTINUE = 'continue'
+KNOWLEDGE_RETRIEVAL_ERROR_POLICIES = {
+    KNOWLEDGE_RETRIEVAL_ERROR_POLICY_FAIL,
+    KNOWLEDGE_RETRIEVAL_ERROR_POLICY_CONTINUE,
+}
 
 
 def _model_has_ability(model: modelmgr_requester.RuntimeLLMModel, ability: str) -> bool:
@@ -292,6 +298,17 @@ class LocalAgentRunner(runner.RequestRunner):
         configured_model.reasoning_config_override = reasoning_config
         return configured_model
 
+    @staticmethod
+    def _knowledge_retrieval_error_policy(query: pipeline_query.Query) -> str:
+        local_agent_config = query.pipeline_config.get('ai', {}).get('local-agent', {})
+        policy = local_agent_config.get(
+            'knowledge-retrieval-error-policy',
+            KNOWLEDGE_RETRIEVAL_ERROR_POLICY_FAIL,
+        )
+        if policy not in KNOWLEDGE_RETRIEVAL_ERROR_POLICIES:
+            return KNOWLEDGE_RETRIEVAL_ERROR_POLICY_FAIL
+        return policy
+
     async def _invoke_with_fallback(
         self,
         query: pipeline_query.Query,
@@ -398,6 +415,8 @@ class LocalAgentRunner(runner.RequestRunner):
             execution_context = get_query_execution_context(query)
 
             kb_engine_plugins: set[str] = set()
+            failed_kb_count = 0
+            knowledge_retrieval_error_policy = self._knowledge_retrieval_error_policy(query)
 
             # Retrieve from each knowledge base
             for kb_uuid in kb_uuids:
@@ -413,15 +432,25 @@ class LocalAgentRunner(runner.RequestRunner):
                     engine_plugin_id = 'builtin'
                 kb_engine_plugins.add(engine_plugin_id)
 
-                result = await kb.retrieve(
-                    execution_context,
-                    user_message_text,
-                    settings={
-                        'bot_uuid': query.bot_uuid or '',
-                        'sender_id': str(query.sender_id),
-                        'session_name': f'{query.session.launcher_type.value}_{query.session.launcher_id}',
-                    },
-                )
+                try:
+                    result = await kb.retrieve(
+                        execution_context,
+                        user_message_text,
+                        settings={
+                            'bot_uuid': query.bot_uuid or '',
+                            'sender_id': str(query.sender_id),
+                            'session_name': f'{query.session.launcher_type.value}_{query.session.launcher_id}',
+                        },
+                    )
+                except Exception as e:
+                    if knowledge_retrieval_error_policy == KNOWLEDGE_RETRIEVAL_ERROR_POLICY_CONTINUE:
+                        failed_kb_count += 1
+                        self.ap.logger.warning(
+                            f'Knowledge base {kb_uuid} retrieve failed, continuing without it: {e}',
+                            exc_info=True,
+                        )
+                        continue
+                    raise
 
                 if result:
                     all_results.extend(result)
@@ -433,6 +462,7 @@ class LocalAgentRunner(runner.RequestRunner):
                 {
                     'kb_count': len(kb_uuids),
                     'engine_plugins': sorted(kb_engine_plugins),
+                    'failed_kb_count': failed_kb_count,
                     'retrieved_entries': len(all_results),
                 },
             )

--- a/src/langbot/templates/default-pipeline-config.json
+++ b/src/langbot/templates/default-pipeline-config.json
@@ -54,6 +54,7 @@
                 }
             ],
             "knowledge-bases": [],
+            "knowledge-retrieval-error-policy": "fail",
             "box-session-id-template": "{launcher_type}_{launcher_id}",
             "rerank-model": "",
             "rerank-top-k": 5

--- a/src/langbot/templates/metadata/pipeline/ai.yaml
+++ b/src/langbot/templates/metadata/pipeline/ai.yaml
@@ -250,6 +250,29 @@ stages:
           field: knowledge-bases
           operator: neq
           value: []
+      - name: knowledge-retrieval-error-policy
+        label:
+          en_US: Knowledge Retrieval Errors
+          zh_Hans: 知识库检索错误
+        description:
+          en_US: Choose whether a Local Agent request should fail or continue without knowledge context when retrieval fails.
+          zh_Hans: 选择知识库检索失败时，内置 Agent 请求是直接失败，还是跳过知识库上下文继续回答。
+        type: select
+        required: false
+        default: fail
+        options:
+          - name: fail
+            label:
+              en_US: Fail the request
+              zh_Hans: 请求失败
+          - name: continue
+            label:
+              en_US: Continue without knowledge context
+              zh_Hans: 跳过知识库继续回答
+        show_if:
+          field: knowledge-bases
+          operator: neq
+          value: []
       - name: rerank-top-k
         label:
           en_US: Rerank Top K

--- a/tests/unit_tests/provider/test_localagent_knowledge_fallback.py
+++ b/tests/unit_tests/provider/test_localagent_knowledge_fallback.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+import langbot_plugin.api.entities.builtin.pipeline.query as pipeline_query
+import langbot_plugin.api.entities.builtin.provider.message as provider_message
+import langbot_plugin.api.entities.builtin.provider.session as provider_session
+
+from langbot.pkg.api.http.context import ExecutionContext
+from langbot.pkg.provider.runners.localagent import LocalAgentRunner
+
+
+class RecordingProvider:
+    def __init__(self):
+        self.requests: list[dict] = []
+
+    async def invoke_llm(self, query, model, messages, funcs, extra_args=None, remove_think=None):
+        self.requests.append(
+            {
+                'messages': list(messages),
+                'funcs': list(funcs),
+                'remove_think': remove_think,
+            }
+        )
+        return provider_message.Message(role='assistant', content='fallback answer')
+
+
+def _make_query(policy: str | None = None) -> pipeline_query.Query:
+    adapter = AsyncMock()
+    adapter.is_stream_output_supported = AsyncMock(return_value=False)
+
+    local_agent_config = {
+        'model': {'primary': 'test-model-uuid', 'fallbacks': []},
+        'prompt': 'test-prompt',
+    }
+    if policy is not None:
+        local_agent_config['knowledge-retrieval-error-policy'] = policy
+
+    query = pipeline_query.Query.model_construct(
+        query_id='knowledge-fallback-query',
+        launcher_type=provider_session.LauncherTypes.PERSON,
+        launcher_id=12345,
+        sender_id=12345,
+        message_chain=[],
+        message_event=None,
+        adapter=adapter,
+        pipeline_uuid='pipeline-uuid',
+        bot_uuid='bot-uuid',
+        pipeline_config={
+            'ai': {
+                'runner': {'runner': 'local-agent'},
+                'local-agent': local_agent_config,
+            },
+            'output': {'misc': {'remove-think': False}},
+        },
+        prompt=SimpleNamespace(messages=[]),
+        messages=[],
+        user_message=provider_message.Message(
+            role='user',
+            content=[provider_message.ContentElement.from_text('hello knowledge')],
+        ),
+        use_funcs=[],
+        use_llm_model_uuid='test-model-uuid',
+        variables={'_knowledge_base_uuids': ['kb-1']},
+        session=SimpleNamespace(
+            launcher_type=provider_session.LauncherTypes.PERSON,
+            launcher_id=12345,
+        ),
+    )
+    object.__setattr__(
+        query,
+        '_execution_context',
+        ExecutionContext(
+            instance_uuid='instance-test',
+            workspace_uuid='workspace-test',
+            placement_generation=1,
+            bot_uuid='bot-uuid',
+            pipeline_uuid='pipeline-uuid',
+            query_uuid='query-knowledge-fallback',
+        ),
+    )
+    object.__setattr__(query, 'query_uuid', 'query-knowledge-fallback')
+    return query
+
+
+def _make_app(provider: RecordingProvider) -> SimpleNamespace:
+    model = SimpleNamespace(
+        provider=provider,
+        model_entity=SimpleNamespace(
+            uuid='test-model-uuid',
+            name='test-model',
+            abilities=[],
+            extra_args={},
+        ),
+    )
+    kb = SimpleNamespace(
+        get_knowledge_engine_plugin_id=Mock(return_value='langbot-team/LangRAG'),
+        retrieve=AsyncMock(side_effect=RuntimeError('embedding unavailable')),
+    )
+    return SimpleNamespace(
+        logger=Mock(),
+        model_mgr=SimpleNamespace(get_model_by_uuid=AsyncMock(return_value=model)),
+        tool_mgr=SimpleNamespace(),
+        rag_mgr=SimpleNamespace(get_knowledge_base_by_uuid=AsyncMock(return_value=kb)),
+        box_service=None,
+        skill_mgr=SimpleNamespace(
+            get_skills_for_pipeline=AsyncMock(return_value=[]),
+            detect_skill_activation=AsyncMock(return_value=None),
+            build_activation_prompt=Mock(return_value=None),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_localagent_knowledge_retrieval_error_fails_by_default():
+    provider = RecordingProvider()
+    app = _make_app(provider)
+    runner = LocalAgentRunner(app, pipeline_config={})
+    query = _make_query()
+
+    with pytest.raises(RuntimeError, match='embedding unavailable'):
+        [message async for message in runner.run(query)]
+
+    assert provider.requests == []
+
+
+@pytest.mark.asyncio
+async def test_localagent_can_continue_when_knowledge_retrieval_fails():
+    provider = RecordingProvider()
+    app = _make_app(provider)
+    runner = LocalAgentRunner(app, pipeline_config={})
+    query = _make_query(policy='continue')
+
+    results = [message async for message in runner.run(query)]
+
+    assert [message.content for message in results] == ['fallback answer']
+    app.logger.warning.assert_called_once()
+    request_user_message = provider.requests[0]['messages'][-1]
+    assert request_user_message.content[0].text == 'hello knowledge'


### PR DESCRIPTION
## Summary
- add a Local Agent setting, `knowledge-retrieval-error-policy`, for handling knowledge base retrieval errors
- preserve existing behavior by default with `fail`
- allow `continue` to skip failed knowledge bases, record `failed_kb_count` telemetry, and continue the chat turn without knowledge context
- expose the setting in default pipeline config and pipeline metadata

## Tests
- `uv run pytest tests/unit_tests/provider/test_localagent_knowledge_fallback.py tests/unit_tests/provider/test_localagent_no_duplicate.py tests/unit_tests/provider/test_localagent_sandbox_exec.py tests/unit_tests/provider/test_localagent_inbound_attachments.py -q`
- `uv run ruff check src/langbot/pkg/provider/runners/localagent.py tests/unit_tests/provider/test_localagent_knowledge_fallback.py`
- parsed `src/langbot/templates/default-pipeline-config.json` and `src/langbot/templates/metadata/pipeline/ai.yaml`