### PR TITLE
chore(release): prepare LangBot 4.10.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot"
-version = "4.10.10"
+version = "4.10.11"
 description = "Production-grade platform for building agentic IM bots"
 readme = "README.md"
 license-files = ["LICENSE"]

--- a/uv.lock
+++ b/uv.lock
@@ -2008,7 +2008,7 @@ wheels = [
 
 [[package]]
 name = "langbot"
-version = "4.10.10"
+version = "4.10.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiocqhttp" },


### PR DESCRIPTION
## Summary
- Bump LangBot version to 4.10.11 in pyproject.toml and uv.lock only.
- Release existing master fixes for OSS knowledge-base file transfer and nested plugin scope (#2528), with published SDK 0.5.8.
- Include intervening master improvements in release notes; no Cloud deployment changes.

## Verification
- Independent two-file review: approved; no semantic dependency changes.
- uv lock --check and frozen Python 3.12 sync passed.
- Frontend production build passed.
- Wheel and sdist build and Twine checks passed; both contain WebUI assets, SDK 0.5.8 pin, no VCS dependencies or bytecode.
- Old/new behavior regression and fresh consumer installation are being verified before publication.

## Release gates
Wait for this exact head CI, merge, then tag the merged SHA. Publish via existing release-event workflows and independently verify GitHub archive, PyPI distributions, and amd64/arm64 image manifests.