### PR TITLE
fix(ci): recover immutable release PyPI builds

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,6 +2,11 @@ name: Build and Publish to PyPI
 
 on:
   workflow_dispatch:
+    inputs:
+      source_ref:
+        description: 'Existing release tag to publish (for example v4.10.11)'
+        required: true
+        type: string
   release:
     types: [published]
 
@@ -11,12 +16,38 @@ jobs:
     permissions:
       contents: read
       id-token: write  # Required for trusted publishing to PyPI
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.source_ref || github.sha }}
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Validate release source and version
+        env:
+          RELEASE_TAG: ${{ inputs.source_ref || github.event.release.tag_name }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import re
+          import subprocess
+          import tomllib
+          from pathlib import Path
+
+          tag = os.environ['RELEASE_TAG']
+          if not re.fullmatch(r'v[0-9]+\.[0-9]+\.[0-9]+', tag):
+              raise SystemExit('source_ref must be an existing release tag: vX.Y.Z')
+          def revision(ref):
+              return subprocess.check_output(['git', 'rev-parse', '--verify', ref], text=True).strip()
+          if revision('HEAD') != revision(f'refs/tags/{tag}^{{}}'):
+              raise SystemExit('Checked-out commit does not match the release tag')
+          version = tomllib.loads(Path('pyproject.toml').read_text())['project']['version']
+          if version != tag[1:]:
+              raise SystemExit(f'Package version {version} does not match tag {tag}')
+          print(f'Validated {tag} at {revision("HEAD")} (package {version})')
+          PY
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -26,9 +57,9 @@ jobs:
       - name: Build frontend
         run: |
           cd web
-          npm install -g pnpm
-          pnpm install
-          pnpm build
+          # Match the archive/Docker npm path; npm ci rejects older tags' stale npm lockfiles.
+          npm install --include=optional
+          npm run build
           mkdir -p ../src/langbot/web/dist
           cp -r dist ../src/langbot/web/
 


### PR DESCRIPTION
## Summary
- Recover release PyPI packaging when pnpm omits Rolldown's Linux optional native binding.
- Use the npm install path already used by release archives and Docker, with optional dependencies explicitly included and TypeScript build retained.
- Add a required manual `source_ref` so an updated workflow can build an existing immutable release tag. Validate tag syntax, exact checkout/tag commit, and package version before installing dependencies.
- Product source, dependency declarations/lockfiles, and v4.10.11 tag remain unchanged.

## Evidence
- Release run 34673325954 failed before Python build/upload on missing `@rolldown/binding-linux-x64-gnu` (633 packages installed).
- Local pnpm clean attempts selected 635 packages and passed on both Node 22.23.1 and 22.23.2; exact CI omission was not reproduced locally. Do not infer a proven Node-specific cause.
- `npm ci` rejects the existing tag's stale npm lock; `npm install --include=optional` works without retagging or changing product source.
- Two separate clean Linux source archives pass npm installation, TypeScript/Vite build and frontend assembly; exact Node 22.23.2 build also passes wheel/sdist generation and metadata/WebUI/cache inspections.
- Workflow structural tests and nine tag/version/commit guard cases pass; actionlint and git diff --check pass.

## Recovery plan
After merge, dispatch this workflow from master with `source_ref=v4.10.11`. The release remains draft until PyPI, release archive, and both container architectures are independently verified. No Cloud production deployment changes.
